### PR TITLE
投稿作成ページの余白を調整

### DIFF
--- a/lib/view/place_post_page.dart
+++ b/lib/view/place_post_page.dart
@@ -50,7 +50,7 @@ class _PlacePostPageState extends State<PlacePostPage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Container(
-              margin: const EdgeInsets.only(bottom: 30, right: 20),
+              margin: const EdgeInsets.only(bottom: 20, right: 20),
               child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -160,6 +160,8 @@ class _PlacePostPageState extends State<PlacePostPage> {
                 ),
               ),
             ),
+            const SizedBox(
+              height: 100,)
           ],
         ),
       ),


### PR DESCRIPTION
投稿作成・編集ページでコメント欄がキーボードに隠れないように修正