### PR TITLE
app_modalにキーボードを避ける機能を追加

### DIFF
--- a/lib/component/app_modal.dart
+++ b/lib/component/app_modal.dart
@@ -4,21 +4,35 @@ import 'package:flutter/Cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:gohan_map/colors/app_colors.dart';
 
+//定数
+//キーボードを避けるためにどれだけ余白をとるか
+const double _avoidKeyboardPadding = 200;
+
 ///下から出てくるモーダルウィジェットの中身の雛形
-class AppModal extends StatelessWidget {
+class AppModal extends StatefulWidget {
   final Widget child; //子要素となるウィジェット
   final double initialChildSize; //初期の大きさが画面の高さの何倍か
   final double minChildSize; //最小の大きさが画面の高さの何倍か
   final double maxChildSize; //最大の大きさが画面の高さの何倍か
   final bool showKnob; //つまみを表示するか
+  final bool avoidKeyboardFlg; //キーボードを避けるかどうか
   const AppModal({
     this.initialChildSize = 0.4,
     this.minChildSize = 0.2,
     this.maxChildSize = 0.9,
     this.showKnob = true,
+    this.avoidKeyboardFlg = false,
     required this.child,
     Key? key,
   }) : super(key: key);
+
+  @override
+  State<AppModal> createState() => _AppModalState();
+}
+
+class _AppModalState extends State<AppModal> {
+  final DraggableScrollableController controller = DraggableScrollableController();
+
   @override
   Widget build(BuildContext context) {
     //modalの高さをNavigationBarに合わせる
@@ -31,19 +45,20 @@ class AppModal extends StatelessWidget {
     // } else {
     //   ratio = maxChildSize;
     // }
-    ratio = maxChildSize;
+    ratio = widget.maxChildSize;
     return GestureDetector(
       //モーダルの外側をタップしたらモーダルを閉じる
       behavior: HitTestBehavior.opaque,
       onTap: () => Navigator.pop(context),
       child: DraggableScrollableSheet(
         //スクロール可能なモーダルウィジェット
+        controller: controller,
         builder: (BuildContext context, scrollController) {
           return InkWell(
             onTap: () {
               //キーボードを閉じる
               FocusScope.of(context).unfocus();
-            },//モーダルの内側をタップしてモーダルを閉じないようにタップイベントを無効化
+            }, //モーダルの内側をタップしてモーダルを閉じないようにタップイベントを無効化
             child: Container(
               //モーダルの中身
               decoration: BoxDecoration(
@@ -66,36 +81,110 @@ class AppModal extends StatelessWidget {
                 child: BackdropFilter(
                   //ぼかすためのウィジェット
                   filter: ImageFilter.blur(sigmaX: 40, sigmaY: 40),
-                  child: SingleChildScrollView(
-                    //DraggableScrollableSheeの子要素は必ずScrollableなウィジェットである必要がある
-                    controller: scrollController,
-                    child: Column(
-                      children: [
-                        if (showKnob)
-                          Container(
-                            margin: const EdgeInsets.fromLTRB(0, 10, 0, 15),
-                            height: 5,
-                            width: 26,
-                            decoration: BoxDecoration(
-                              color: const Color(0x16000000),
-                              borderRadius: BorderRadius.circular(2.5),
-                            ),
-                          ),
-                        SizedBox(
-                          width: double.infinity,
-                          child: child,
-                        ),
-                      ],
-                    ),
-                  ),
+                  child: _ChildScrollView(draggableController: controller, scrollController: scrollController, avoidKeyboard: widget.avoidKeyboardFlg, showKnob: widget.showKnob, child: widget.child),
                 ),
               ),
             ),
           );
         },
-        initialChildSize: initialChildSize /*最初の大きさが親ウェジェットの何倍か*/,
-        minChildSize: minChildSize /*最小の大きさが親ウェジェットの何倍か*/,
+        initialChildSize: widget.initialChildSize /*最初の大きさが親ウェジェットの何倍か*/,
+        minChildSize: widget.minChildSize /*最小の大きさが親ウェジェットの何倍か*/,
         maxChildSize: ratio /*最大の大きさが親ウェジェットの何倍か*/,
+      ),
+    );
+  }
+}
+
+//モーダル内のスクロール可能な領域
+//スクロールを実行するためにはscrollControllerが必要なのでここでStatefulWidgetを使用
+class _ChildScrollView extends StatefulWidget {
+  const _ChildScrollView({
+    super.key,
+    required this.draggableController,
+    required this.scrollController,
+    required this.avoidKeyboard,
+    required this.showKnob,
+    required this.child,
+  });
+
+  final DraggableScrollableController draggableController;
+  final ScrollController scrollController;
+  final bool showKnob;
+  final bool avoidKeyboard;
+  final Widget child;
+
+  @override
+  State<_ChildScrollView> createState() => _ChildScrollViewState();
+}
+
+class _ChildScrollViewState extends State<_ChildScrollView> {
+  //余白をつけるかどうかのフラグ
+  //フォーカスアウト時はアニメーションが終わるまでの遅延を入れるため、avoidKeyboardとは別のフラグを定義
+  bool existMargin = false;
+
+  @override
+  void didUpdateWidget(covariant _ChildScrollView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.avoidKeyboard != oldWidget.avoidKeyboard) {
+      // avoidKeyboardの値が変更された場合に実行する処理
+      if (widget.avoidKeyboard) {
+        // フォーカスされた場合の処理
+        existMargin = true;
+        widget.draggableController
+            .animateTo(
+          1,
+          duration: const Duration(milliseconds: 100),
+          curve: Curves.easeIn,
+        )
+            .then((value) {
+          widget.scrollController.animateTo(
+            widget.scrollController.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOut,
+          );
+        });
+      } else {
+        // フォーカスが外れた場合の処理
+        widget.scrollController
+            .animateTo(
+          widget.scrollController.position.maxScrollExtent - _avoidKeyboardPadding,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        )
+            .then((value) {
+          existMargin = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      //DraggableScrollableSheeの子要素は必ずScrollableなウィジェットである必要がある
+      controller: widget.scrollController,
+      child: Column(
+        children: [
+          if (widget.showKnob)
+            Container(
+              margin: const EdgeInsets.fromLTRB(0, 10, 0, 15),
+              height: 5,
+              width: 26,
+              decoration: BoxDecoration(
+                color: const Color(0x16000000),
+                borderRadius: BorderRadius.circular(2.5),
+              ),
+            ),
+          SizedBox(
+            width: double.infinity,
+            child: widget.child,
+          ),
+          if (existMargin)
+            const SizedBox(
+              height: _avoidKeyboardPadding,
+            ),
+        ],
       ),
     );
   }

--- a/lib/component/post_food_widget.dart
+++ b/lib/component/post_food_widget.dart
@@ -21,6 +21,7 @@ class PostFoodWidget extends StatelessWidget {
     required this.onDateChanged,
     this.initialComment,
     required this.onCommentChanged,
+    this.onCommentFocusChanged,
   }) : super(key: key);
   final File? initialImage;
   final Function(File?) onImageChanged;
@@ -33,6 +34,8 @@ class PostFoodWidget extends StatelessWidget {
 
   final String? initialComment;
   final Function(String) onCommentChanged;
+
+  final Function(bool)? onCommentFocusChanged;
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -46,20 +49,21 @@ class PostFoodWidget extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _ImgSection(
-            initialImage: this.initialImage,
+            initialImage: initialImage,
             onChanged: onImageChanged,
           ),
           UmaiButton(
-            initialIsUmai: this.initialIsUmai,
+            initialIsUmai: initialIsUmai,
             onChanged: onUmaiChanged,
           ),
           _DateSection(
-            initialDate: this.initialDate,
+            initialDate: initialDate,
             onChanged: onDateChanged,
           ),
           _CommentSection(
-            initialComment: this.initialComment,
+            initialComment: initialComment,
             onChanged: onCommentChanged,
+            onFocusChanged: onCommentFocusChanged,
           ),
         ],
       ),
@@ -71,7 +75,6 @@ class _ImgSection extends StatefulWidget {
   final File? initialImage;
   final Function(File?) onChanged;
   const _ImgSection({
-    super.key,
     this.initialImage,
     required this.onChanged,
   });
@@ -343,9 +346,7 @@ class _DateSection extends StatelessWidget {
         dateMask: 'yyyy/MM/dd',
         //icon: Icon(Icons.watch_later_outlined),
         dateLabelText: '訪問日',
-        initialValue: initialDate != null
-            ? initialDate.toString()
-            : DateTime.now().toString(),
+        initialValue: initialDate != null ? initialDate.toString() : DateTime.now().toString(),
         use24HourFormat: true,
         onChanged: (value) {
           onChanged(DateTime.parse(value));
@@ -361,37 +362,41 @@ class _CommentSection extends StatelessWidget {
     super.key,
     this.initialComment,
     required this.onChanged,
+    this.onFocusChanged,
   });
   final String? initialComment;
   final Function(String) onChanged;
+  final Function(bool)? onFocusChanged;
 
   @override
   Widget build(BuildContext context) {
-    return TextFormField(
-      keyboardType: TextInputType.multiline,
-      maxLines: null,
-      minLines: 3,
-      initialValue: initialComment,
-      decoration: InputDecoration(
-        hintText: 'コメント',
-        filled: true,
-        fillColor: AppColors.searchBarColor,
-        contentPadding:
-            const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        enabledBorder: OutlineInputBorder(
-          borderSide: const BorderSide(
-            color: AppColors.textFieldColor,
+    return Focus(
+      onFocusChange: onFocusChanged,
+      child: TextFormField(
+        keyboardType: TextInputType.multiline,
+        maxLines: null,
+        minLines: 3,
+        initialValue: initialComment,
+        decoration: InputDecoration(
+          hintText: 'コメント',
+          filled: true,
+          fillColor: AppColors.searchBarColor,
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          enabledBorder: OutlineInputBorder(
+            borderSide: const BorderSide(
+              color: AppColors.textFieldColor,
+            ),
+            borderRadius: BorderRadius.circular(8),
           ),
-          borderRadius: BorderRadius.circular(8),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderSide: const BorderSide(
-            color: AppColors.textFieldColor,
+          focusedBorder: OutlineInputBorder(
+            borderSide: const BorderSide(
+              color: AppColors.textFieldColor,
+            ),
+            borderRadius: BorderRadius.circular(8),
           ),
-          borderRadius: BorderRadius.circular(8),
         ),
+        onChanged: onChanged,
       ),
-      onChanged: onChanged,
     );
   }
 }

--- a/lib/view/place_create_page.dart
+++ b/lib/view/place_create_page.dart
@@ -35,10 +35,13 @@ class _PlaceCreatePageState extends State<PlaceCreatePage> {
   bool isUmai = false;
   DateTime date = DateTime.now();
   String comment = '';
+  bool avoidkeyBoard = false;
+
   @override
   Widget build(BuildContext context) {
     return AppModal(
       initialChildSize: 0.6,
+      avoidKeyboardFlg: avoidkeyBoard,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16),
         child: Column(
@@ -145,6 +148,11 @@ class _PlaceCreatePageState extends State<PlaceCreatePage> {
                   this.comment = comment;
                 });
               },
+              onCommentFocusChanged: (isFocus) {
+                setState(() {
+                  avoidkeyBoard = isFocus;
+                });
+              },
             ),
             //決定ボタン
             Container(
@@ -162,10 +170,38 @@ class _PlaceCreatePageState extends State<PlaceCreatePage> {
                 onPressed: () {
                   _onTapComfirm(context);
                 },
-                child: const Text('決定'),
+                child: const Text(
+                  '決定',
+                  style: TextStyle(
+                      color: AppColors.blueTextColor,
+                      fontWeight: FontWeight.bold),
+                ),
               ),
             ),
-            const SizedBox(height: 300),
+            // キャンセルボタン
+            Container(
+              width: double.infinity,
+              height: 50,
+              margin: const EdgeInsets.only(bottom: 50),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  foregroundColor: AppColors.blackTextColor,
+                  backgroundColor: AppColors.backgroundWhiteColor,
+                ),
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+                child: const Text(
+                  'キャンセル',
+                  style: TextStyle(
+                      color: AppColors.redTextColor,
+                      fontWeight: FontWeight.bold),
+                ),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/view/place_post_page.dart
+++ b/lib/view/place_post_page.dart
@@ -28,7 +28,7 @@ class _PlacePostPageState extends State<PlacePostPage> {
   bool isUmai = false;
   DateTime date = DateTime.now();
   String comment = '';
-
+  bool avoidkeyBoard = false;
   @override
   void initState() {
     super.initState();
@@ -44,6 +44,7 @@ class _PlacePostPageState extends State<PlacePostPage> {
   Widget build(BuildContext context) {
     return AppModal(
       initialChildSize: 0.6,
+      avoidKeyboardFlg: avoidkeyBoard,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16),
         child: Column(
@@ -111,6 +112,11 @@ class _PlacePostPageState extends State<PlacePostPage> {
                   this.comment = comment;
                 });
               },
+              onCommentFocusChanged: (isFocus) {
+                setState(() {
+                  avoidkeyBoard = isFocus;
+                });
+              },
             ),
             //決定ボタン
             Container(
@@ -160,8 +166,6 @@ class _PlacePostPageState extends State<PlacePostPage> {
                 ),
               ),
             ),
-            const SizedBox(
-              height: 100,)
           ],
         ),
       ),

--- a/lib/view/place_post_page.dart
+++ b/lib/view/place_post_page.dart
@@ -168,9 +168,6 @@ class _PlacePostPageState extends State<PlacePostPage> {
                 ),
               ),
             ),
-            const SizedBox(
-              height: 100,
-            )
           ],
         ),
       ),


### PR DESCRIPTION
AppModalに新たな引数を追加しました。
```dart
  final bool avoidKeyboardFlg; //キーボードを避けるかどうか
```
AppModalをStatefulWidgetに変更し、didUpdateWidgetを使ってavoidKeyboardFlgの値の変化をチェックしてます👀

## avoidKeyboardFlg
avoidKeyboardFlgがTrueになった場合には以下の処理が逐次実行
 - 下端に余白を200px確保
 - Modalを一番上まで引っ張った状態にする(100ms)
 - Modal内を一番下までスクロールする(200ms)

avoidKeyboardFlgがFalseになった場合には以下の処理が逐次実行
 - Modal内を上方向に200pxスクロールする(200ms)
 - 200px確保した下端の余白を削除


lib/view/place_post_page.dart で動作するように実装したので動作確認おなしゃす
