### PR TITLE
モーダルの背景を単色にする

### DIFF
--- a/lib/colors/app_colors.dart
+++ b/lib/colors/app_colors.dart
@@ -10,6 +10,7 @@ class AppColors {
   static const Color textFieldColor = Color(0xffffffff);
   static const Color backgroundWhiteColor = Color(0xffffffff);
   static const Color backgroundGrayColor = Color(0xffd9d9d9);
-  static const Color backgroundModalColor = Color(0x99ffffff);
+  static const Color bluredModalColor = Color(0x99ffffff);
+  static const Color unBluredModalColor = Color(0xFFE1DAD1);
   static const Color pinColor = Color.fromARGB(255, 255, 0, 0);
 }

--- a/lib/component/app_modal.dart
+++ b/lib/component/app_modal.dart
@@ -23,7 +23,7 @@ class AppModal extends StatefulWidget {
     this.maxChildSize = 0.9,
     this.showKnob = true,
     this.avoidKeyboardFlg = false,
-    this.backgroundColor = AppColors.backgroundModalColor,
+    this.backgroundColor = AppColors.unBluredModalColor,
     required this.child,
     Key? key,
   }) : super(key: key);
@@ -69,35 +69,24 @@ class _AppModalState extends State<AppModal> {
                   topRight: Radius.circular(20.0),
                 ),
               ),
-              child: ClipRRect(
-                //ぼかす領域を指定するためのウィジェット
-                borderRadius: const BorderRadius.only(
-                  topLeft: Radius.circular(20.0),
-                  topRight: Radius.circular(20.0),
-                ),
-                child: BackdropFilter(
-                  //ぼかすためのウィジェット
-                  filter: ImageFilter.blur(sigmaX: 40, sigmaY: 40),
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: AppColors.backgroundModalColor,
-                      border: Border.all(
-                      color: AppColors.backgroundGrayColor,
-                      width: 1,
-                      ),
-                      borderRadius: const BorderRadius.only(
-                        topLeft: Radius.circular(20.0),
-                        topRight: Radius.circular(20.0),
-                      ),
-                    ),
-                    child: _ChildScrollView(
-                        draggableController: controller,
-                        scrollController: scrollController,
-                        avoidKeyboard: widget.avoidKeyboardFlg,
-                        showKnob: widget.showKnob,
-                        child: widget.child),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: AppColors.bluredModalColor,
+                  border: Border.all(
+                  color: AppColors.backgroundGrayColor,
+                  width: 1,
+                  ),
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(20.0),
+                    topRight: Radius.circular(20.0),
                   ),
                 ),
+                child: _ChildScrollView(
+                    draggableController: controller,
+                    scrollController: scrollController,
+                    avoidKeyboard: widget.avoidKeyboardFlg,
+                    showKnob: widget.showKnob,
+                    child: widget.child),
               ),
             ),
           );

--- a/lib/view/map_page.dart
+++ b/lib/view/map_page.dart
@@ -135,7 +135,7 @@ class _MapPageState extends State<MapPage> with TickerProviderStateMixin {
                 child: Container(
                   //モーダル風UIの中身
                   decoration: BoxDecoration(
-                    color: AppColors.backgroundModalColor,
+                    color: AppColors.bluredModalColor,
                     border: Border.all(
                       color: AppColors.backgroundGrayColor,
                       width: 1,


### PR DESCRIPTION
モーダルのデフォルト背景色は半透明+弱いブラーをかけていたが、
モーダルが2枚重なっているときに上のモーダルの背景色がほぼ真っ白になってしまう現象を解決できなかった。
よく考えたらブラー処理によるパフォーマンスへの悪影響も懸念されていたので、ブラーをやめてモーダルのデフォルト背景色を単色の
unBluredModalColor = Color(0xFFE1DAD1);
に変更してみた。
<img width="570" alt="スクリーンショット 2023-08-14 15 37 35" src="https://github.com/toyoshin5/gohan_map/assets/43494392/dad9f94c-faa7-49fb-bfc8-b6ef1f84a735">