### PR TITLE
タブバーを使って画面を切り替える

### DIFF
--- a/lib/bottom_navigation.dart
+++ b/lib/bottom_navigation.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:gohan_map/main.dart';
+
+const tabTitle = <TabItem, String>{
+  TabItem.map: 'マップ',
+  TabItem.allpost: '投稿一覧',
+  TabItem.character: '育成',
+};
+const tabIcon = <TabItem, IconData>{
+  TabItem.map: Icons.map,
+  TabItem.allpost: Icons.list,
+  TabItem.character: Icons.mood,
+};
+
+class BottomNavigation extends StatelessWidget {
+  const BottomNavigation({
+    Key? key,
+    required this.currentTab,
+    required this.onSelect,
+  }) : super(key: key);
+
+  final TabItem currentTab;
+  final ValueChanged<TabItem> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      items: <BottomNavigationBarItem>[
+        bottomItem(
+          context,
+          tabItem: TabItem.map,
+        ),
+        bottomItem(
+          context,
+          tabItem: TabItem.allpost,
+        ),
+        bottomItem(
+          context,
+          tabItem: TabItem.character,
+        ),
+      ],
+      type: BottomNavigationBarType.fixed,
+      selectedFontSize: 12,
+      onTap: (index) {
+        onSelect(TabItem.values[index]);
+      },
+    );
+  }
+
+  BottomNavigationBarItem bottomItem(
+    BuildContext context, {
+    required TabItem tabItem,
+  }) {
+    final color = currentTab == tabItem ? Colors.blue : Colors.black26;
+    return BottomNavigationBarItem(
+      icon: Column(
+        children: [
+          Icon(
+            tabIcon[tabItem],
+            color: color,
+          ),
+          Text(tabTitle[tabItem] ?? '',
+              style: TextStyle(
+                color: color,
+                fontSize: 12,
+              )),
+        ],
+      ),
+      label: '',
+    );
+  }
+}

--- a/lib/component/app_map.dart
+++ b/lib/component/app_map.dart
@@ -162,41 +162,6 @@ class _AppMapState extends State<AppMap> with TickerProviderStateMixin {
                 ],
               );
             }),
-
-        //右上のボタン
-        Positioned(
-          top: 50,
-          right: 20,
-          child: SizedBox(
-            height: 44,
-            child: ElevatedButton(
-              //角丸で白
-              style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.all(0),
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.all(Radius.circular(10)),
-                ),
-                backgroundColor: Colors.white,
-                foregroundColor: AppColors.blueTextColor,
-              ),
-              onPressed: () {
-                Navigator.push(
-                    context,
-                    CupertinoPageRoute(
-                        builder: (context) => const AllPostPage()));
-              },
-              child: const Padding(
-                padding: EdgeInsets.symmetric(horizontal: 12),
-                child: Row(
-                  children: [
-                    Icon(Icons.format_list_bulleted),
-                    Text("すべての投稿",style: TextStyle(fontWeight: FontWeight.bold),), 
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
         //右下のボタン
         Positioned(
           bottom: 120,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -139,6 +139,8 @@ class _MainPageState extends State<MainPage> {
       characterPageState?.reload();
     }
     //タブの最初の画面に戻る
-    _navigatorKeys[tabItem]?.currentState?.popUntil((route) => route.isFirst);
+    _navigatorKeys[TabItem.allpost]?.currentState?.popUntil((route) => route.isFirst);
+    _navigatorKeys[TabItem.map]?.currentState?.popUntil((route) => route.isFirst);
+    _navigatorKeys[TabItem.character]?.currentState?.popUntil((route) => route.isFirst);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,9 @@ import 'package:gohan_map/bottom_navigation.dart';
 import 'package:gohan_map/tab_navigator.dart';
 import 'package:gohan_map/utils/logger.dart';
 import 'package:gohan_map/utils/safearea_utils.dart';
+import 'package:gohan_map/view/all_post_page.dart';
+import 'package:gohan_map/view/character_page.dart';
+import 'package:gohan_map/view/map_page.dart';
 
 /// アプリが起動したときに呼ばれる
 void main() {
@@ -64,8 +67,17 @@ class _MainPageState extends State<MainPage> {
     TabItem.character: GlobalKey<NavigatorState>(),
   };
 
+  //globalKeyは、ウィジェットの状態を保存するためのもの
+  final Map<TabItem, GlobalKey<State>> _globalKeys = {
+    TabItem.map: GlobalKey<State>(),
+    TabItem.allpost: GlobalKey<State>(),
+    TabItem.character: GlobalKey<State>(),
+  };
+
+  final allpostKey = GlobalKey<AllPostPageState>();
+
   @override
- Widget build(BuildContext context) {
+  Widget build(BuildContext context) {
     return Scaffold(
       body: Stack(
         children: <Widget>[
@@ -94,26 +106,39 @@ class _MainPageState extends State<MainPage> {
     TabItem tabItem,
     String root,
   ) {
-    return Offstage(//Offstageは、子要素を非表示にするウィジェット
+    return Offstage(
+      //Offstageは、子要素を非表示にするウィジェット
       offstage: _currentTab != tabItem,
       child: TabNavigator(
         navigationKey: _navigatorKeys[tabItem]!,
         tabItem: tabItem,
         routerName: root,
+        globalKey: _globalKeys[tabItem]!,
       ),
     );
   }
 
   //タブが選択されたときに呼ばれる。tabItemは選択されたタブ
   void onSelect(TabItem tabItem) {
-    //選択されたタブが現在のタブと同じなら、そのタブの最初の画面に戻る
-    if (_currentTab == tabItem) {
+    setState(() {
+      _currentTab = tabItem;
+    });
+    //選択されたタブをリロードする
+    if (tabItem == TabItem.allpost) {
+      AllPostPageState? allpostPageState =
+            _globalKeys[tabItem]!.currentState as AllPostPageState?;
+      allpostPageState?.reload();
       _navigatorKeys[tabItem]?.currentState?.popUntil((route) => route.isFirst);
-    } else {
-      setState(() {
-        _currentTab = tabItem;
-      });
+    }else if(tabItem == TabItem.map){
+      MapPageState? mapPageState =
+           _globalKeys[tabItem]!.currentState as MapPageState?;
+      mapPageState?.reload();
+    }else if (tabItem == TabItem.character) {
+      CharacterPageState? characterPageState =
+           _globalKeys[tabItem]!.currentState as CharacterPageState?;
+      characterPageState?.reload();
     }
+    //タブの最初の画面に戻る
+    _navigatorKeys[tabItem]?.currentState?.popUntil((route) => route.isFirst);
   }
-
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:gohan_map/utils/logger.dart';
 import 'package:gohan_map/utils/safearea_utils.dart';
+import 'package:gohan_map/view/all_post_page.dart';
+import 'package:gohan_map/view/character_page.dart';
 import 'package:gohan_map/view/map_page.dart';
 
 /// アプリが起動したときに呼ばれる
@@ -36,8 +38,68 @@ class MyApp extends StatelessWidget {
         //appBar: AppBar(
         //  title: const Text('Gohan Map'),
         //),
-        body: MapPage(),
+        body: MainPage(),
       ),
+    );
+  }
+}
+
+
+//タブ(BottomNavigationBar)を含んだ画面
+class MainPage extends StatefulWidget {
+  const MainPage({Key? key}) : super(key: key);
+  @override
+  State<MainPage> createState() => _MainPageState();
+}
+
+class _MainPageState extends State<MainPage> {
+  int _currentIndex = 0;
+  final items = <BottomNavigationBarItem>[
+    const BottomNavigationBarItem(
+      icon: Icon(Icons.map),
+      label: "マップ",
+    ),
+    const BottomNavigationBarItem(
+      icon: Icon(Icons.list),
+      label: "投稿一覧",
+    ),
+    const BottomNavigationBarItem(
+      icon: Icon(Icons.mood),
+      label: "育成",
+    ),
+  ];
+  final tabs = <Widget>[
+    const MapPage(),
+    const AllPostPage(),
+    const CharacterPage(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: <Widget>[
+          IndexedStack(
+            index: _currentIndex,
+            children: tabs,
+          ),
+        ],
+      ),
+      bottomNavigationBar: _buildBttomNavigator(context),
+    );
+  }
+
+  Widget _buildBttomNavigator(BuildContext context) {
+    return BottomNavigationBar(
+      items: items,
+      currentIndex: _currentIndex,
+      onTap: (index) {
+        if (_currentIndex != index) {
+          setState(() {
+            _currentIndex = index;
+          });
+        }
+      },
     );
   }
 }

--- a/lib/tab_navigator.dart
+++ b/lib/tab_navigator.dart
@@ -12,16 +12,18 @@ class TabNavigator extends StatelessWidget {
     required this.tabItem,
     required this.routerName,
     required this.navigationKey,
+    required this.globalKey,
   }) : super(key: key);
 
   final TabItem tabItem;
   final String routerName;
   final GlobalKey<NavigatorState> navigationKey;
+  final GlobalKey<State> globalKey;
 
   Map<String, Widget Function(BuildContext)> _routerBuilder(BuildContext context) => {
-    '/map': (context) => const MapPage(),
-    '/allpost': (context) => const AllPostPage(),
-    '/character': (context) => const CharacterPage(),
+    '/map': (context) => MapPage(key: globalKey,),
+    '/allpost': (context) => AllPostPage(key: globalKey,),
+    '/character': (context) => CharacterPage(key : globalKey,),
   };
 
   @override

--- a/lib/tab_navigator.dart
+++ b/lib/tab_navigator.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/Material.dart';
+import 'package:gohan_map/main.dart';
+import 'package:gohan_map/view/all_post_page.dart';
+import 'package:gohan_map/view/character_page.dart';
+import 'package:gohan_map/view/map_page.dart';
+
+//現在のタブによって、Navigatorを切り替えるためのクラス
+//これを使うことで、タブの内部で画面遷移ができる
+class TabNavigator extends StatelessWidget {
+  const TabNavigator({
+    Key? key,
+    required this.tabItem,
+    required this.routerName,
+    required this.navigationKey,
+  }) : super(key: key);
+
+  final TabItem tabItem;
+  final String routerName;
+  final GlobalKey<NavigatorState> navigationKey;
+
+  Map<String, Widget Function(BuildContext)> _routerBuilder(BuildContext context) => {
+    '/map': (context) => const MapPage(),
+    '/allpost': (context) => const AllPostPage(),
+    '/character': (context) => const CharacterPage(),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final routerBuilder = _routerBuilder(context);
+
+    return Navigator(
+      key: navigationKey,
+      initialRoute: '/',
+      onGenerateRoute: (settings) {
+        return MaterialPageRoute<Widget>(
+          builder: (context) {
+            return routerBuilder[routerName]!(context);
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/view/all_post_page.dart
+++ b/lib/view/all_post_page.dart
@@ -47,13 +47,6 @@ class _AllPostPageState extends State<AllPostPage> {
           'すべての投稿',
           style: TextStyle(color: Colors.black),
         ),
-        leading: IconButton(
-          icon: const Icon(
-            Icons.arrow_back_ios,
-            color: Colors.black,
-          ),
-          onPressed: () => Navigator.pop(context),
-        ),
         //色
         backgroundColor: Colors.white,
       ),

--- a/lib/view/all_post_page.dart
+++ b/lib/view/all_post_page.dart
@@ -16,15 +16,24 @@ class AllPostPage extends StatefulWidget {
   const AllPostPage({super.key});
 
   @override
-  State<AllPostPage> createState() => _AllPostPageState();
+  State<AllPostPage> createState() => AllPostPageState();
 }
 
-class _AllPostPageState extends State<AllPostPage> {
+class AllPostPageState extends State<AllPostPage> {
   List<Timeline>? shopTimeline;
   int segmentIndex = 1;
   @override
   void initState() {
     super.initState();
+    () async {
+      final timelines = await IsarUtils.getAllTimelines();
+      setState(() {
+        shopTimeline = timelines;
+      });
+    }();
+  }
+
+  void reload(){
     () async {
       final timelines = await IsarUtils.getAllTimelines();
       setState(() {

--- a/lib/view/character_page.dart
+++ b/lib/view/character_page.dart
@@ -1,12 +1,23 @@
 import 'package:flutter/material.dart';
 
-class CharacterPage extends StatelessWidget {
+class CharacterPage extends StatefulWidget {
   const CharacterPage({super.key});
 
+  @override
+  State<CharacterPage> createState() => CharacterPageState();
+}
+
+class CharacterPageState extends State<CharacterPage> {
   @override
   Widget build(BuildContext context) {
     return const Center(
       child: Text("育成ページ",style: TextStyle(fontSize: 30,fontWeight: FontWeight.bold),),
     );
+  }
+
+
+  //タブを選択した時に行う再描画処理
+  void reload() {
+
   }
 }

--- a/lib/view/character_page.dart
+++ b/lib/view/character_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class CharacterPage extends StatelessWidget {
+  const CharacterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text("育成ページ",style: TextStyle(fontSize: 30,fontWeight: FontWeight.bold),),
+    );
+  }
+}

--- a/lib/view/place_update_page.dart
+++ b/lib/view/place_update_page.dart
@@ -48,7 +48,6 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
   late double shopStar;
   bool isValidating = false;
 
-  
   @override
   Widget build(BuildContext context) {
     final String? pinImgPath = findPinByKind(shopMapIconKind)?.pinImagePath;
@@ -128,7 +127,8 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
                       builder: (context, snapshot) {
                         if (snapshot.hasData) {
                           final pref = snapshot.data as SharedPreferences;
-                          final currentTileURL = pref.getString("currentTileURL");
+                          final currentTileURL =
+                              pref.getString("currentTileURL");
                           return FlutterMap(
                             mapController: mapController,
                             options: MapOptions(
@@ -150,8 +150,7 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
                             ),
                             children: [
                               TileLayer(
-                                urlTemplate:
-                                    currentTileURL,
+                                urlTemplate: currentTileURL,
                               ),
                             ],
                           );
@@ -163,7 +162,7 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
                       },
                     ),
                   ),
-                     
+
                   //上にimages/pin.pngを重ねる。ただしピンの下端がSizedBoxの中心になるようにする。
                   Align(
                     alignment: Alignment.center,
@@ -339,6 +338,7 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
     );
   }
 
+  bool isDeleted = false;
 //決定ボタンを押した時の処理
   Future<void> _onTapComfirm(BuildContext context) async {
     setState(() {
@@ -438,23 +438,30 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
                 ),
                 onPressed: () async {
                   await IsarUtils.deleteShop(widget.shop.id);
-                  if (mounted) {
+                  if (context.mounted) {
                     setState(() {
                       // reload
                     });
-                    Navigator.of(context).popUntil((route) => route.isFirst);
+                    isDeleted = true;
+                    Navigator.of(context, rootNavigator: true)
+                        .pop(context); //rootNavigator: trueを指定しないと、モーダルが閉じない
                   }
                 },
-              ),
+              )
             ],
             cancelButton: CupertinoActionSheetAction(
               child: const Text('キャンセル'),
               onPressed: () {
-                Navigator.pop(context);
+                isDeleted = false;
+                Navigator.of(context, rootNavigator: true).pop(context);
               },
             ));
       },
-    );
+    ).then((value) {
+      if (isDeleted){
+        Navigator.of(context).popUntil((route) => route.isFirst);
+      }
+    });
   }
 
   void _animatedMapMove(LatLng destLocation, double destZoom, int millsec) {


### PR DESCRIPTION
## 実装内容
 - 画面下部のタブバーを作成して画面を切り替えられるように実装
 - マップ画面にあった"すべての投稿"ボタンを削除し、タブ項目に移動
 - Navigator.push()などでの画面遷移時に、タブ内で画面が遷移するようにした
   - タブ内で遷移するので、タブバーが隠れないように遷移する
   - タブバーが隠れるように遷移したい場面があったら言ってください。方法はあります
 - タブを切り替えたときにページをリロードするようにした
   - "マップ","投稿一覧"タブ両方で投稿の更新削除が可能なので、整合性を維持するために必ずリロードする