### PR TITLE
ピン選択時のアニメーション挙動の修正

### DIFF
--- a/lib/view/map_page.dart
+++ b/lib/view/map_page.dart
@@ -236,12 +236,16 @@ class MapPageState extends State<MapPage> with TickerProviderStateMixin {
                 onTap: () {
                   //ピンをタップしたときの処理
                   if (shop != null) {
-                    setState(() {
-                      tapFlgs[shop.id] = true;
-                    });
+                    //マップを自動スクロールする
                     final deviceHeight = MediaQuery.of(context).size.height;
                     _moveToPin(latLng, deviceHeight * 0.2);
-                    showModalBottomSheet(
+                    HapticFeedback.heavyImpact();
+                    //500ms後にモーダルを表示する
+                    Future.delayed(const Duration(milliseconds: 300), () {
+                      setState(() {
+                        tapFlgs[shop.id] = true;
+                      });
+                      showModalBottomSheet(
                       barrierColor: Colors.black.withOpacity(0),
                       isDismissible: true,
                       isScrollControlled: true,
@@ -253,6 +257,7 @@ class MapPageState extends State<MapPage> with TickerProviderStateMixin {
                         ); //飲食店の詳細画面
                       },
                     ).then((value) => _onModalPop(value, shop.id));
+                    });
                   }
                 },
                 child: Stack(

--- a/lib/view/map_page.dart
+++ b/lib/view/map_page.dart
@@ -240,7 +240,7 @@ class MapPageState extends State<MapPage> with TickerProviderStateMixin {
                     final deviceHeight = MediaQuery.of(context).size.height;
                     _moveToPin(latLng, deviceHeight * 0.2);
                     HapticFeedback.heavyImpact();
-                    //500ms後にモーダルを表示する
+                    //300ms後にモーダルを表示する
                     Future.delayed(const Duration(milliseconds: 300), () {
                       setState(() {
                         tapFlgs[shop.id] = true;


### PR DESCRIPTION
## 何が起きているか
ピンが多いときに、ピン選択時のピン拡大アニメーションがおかしくなる。

## 再現手順
ピン選択時のスクロールによって他のピンが画面外に行くような場合に発生

## 修正内容
マップのスクロールとピンの拡大を同時に行わないようにした

マップのスクロール--(300ms)-->ピン拡大+モーダル表示

## 補足
マップのスクロールは開始から終了まで500msだが
ピン拡大の遅延を500msにすると遅い感覚があるので
ひとまず300msに設定

## どうなったか
不自然なアニメーションは治った(多分)