### PR TITLE
Issue#105/want to go

### DIFF
--- a/lib/collections/shop.dart
+++ b/lib/collections/shop.dart
@@ -11,6 +11,7 @@ class Shop {
   late String shopName;
   late String shopAddress;
   late String shopMapIconKind;
+  late bool wantToGoFlg;
   late double shopLatitude;
   late double shopLongitude;
   late DateTime createdAt;

--- a/lib/collections/shop.g.dart
+++ b/lib/collections/shop.g.dart
@@ -61,6 +61,11 @@ const ShopSchema = CollectionSchema(
       id: 8,
       name: r'updatedAt',
       type: IsarType.dateTime,
+    ),
+    r'wantToGoFlg': PropertySchema(
+      id: 9,
+      name: r'wantToGoFlg',
+      type: IsarType.bool,
     )
   },
   estimateSize: _shopEstimateSize,
@@ -111,6 +116,7 @@ void _shopSerialize(
   writer.writeString(offsets[6], object.shopMapIconKind);
   writer.writeString(offsets[7], object.shopName);
   writer.writeDateTime(offsets[8], object.updatedAt);
+  writer.writeBool(offsets[9], object.wantToGoFlg);
 }
 
 Shop _shopDeserialize(
@@ -130,6 +136,7 @@ Shop _shopDeserialize(
   object.shopMapIconKind = reader.readString(offsets[6]);
   object.shopName = reader.readString(offsets[7]);
   object.updatedAt = reader.readDateTime(offsets[8]);
+  object.wantToGoFlg = reader.readBool(offsets[9]);
   return object;
 }
 
@@ -158,6 +165,8 @@ P _shopDeserializeProp<P>(
       return (reader.readString(offset)) as P;
     case 8:
       return (reader.readDateTime(offset)) as P;
+    case 9:
+      return (reader.readBool(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
   }
@@ -1197,6 +1206,16 @@ extension ShopQueryFilter on QueryBuilder<Shop, Shop, QFilterCondition> {
       ));
     });
   }
+
+  QueryBuilder<Shop, Shop, QAfterFilterCondition> wantToGoFlgEqualTo(
+      bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'wantToGoFlg',
+        value: value,
+      ));
+    });
+  }
 }
 
 extension ShopQueryObject on QueryBuilder<Shop, Shop, QFilterCondition> {}
@@ -1309,6 +1328,18 @@ extension ShopQuerySortBy on QueryBuilder<Shop, Shop, QSortBy> {
   QueryBuilder<Shop, Shop, QAfterSortBy> sortByUpdatedAtDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'updatedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Shop, Shop, QAfterSortBy> sortByWantToGoFlg() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wantToGoFlg', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Shop, Shop, QAfterSortBy> sortByWantToGoFlgDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wantToGoFlg', Sort.desc);
     });
   }
 }
@@ -1433,6 +1464,18 @@ extension ShopQuerySortThenBy on QueryBuilder<Shop, Shop, QSortThenBy> {
       return query.addSortBy(r'updatedAt', Sort.desc);
     });
   }
+
+  QueryBuilder<Shop, Shop, QAfterSortBy> thenByWantToGoFlg() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wantToGoFlg', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Shop, Shop, QAfterSortBy> thenByWantToGoFlgDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'wantToGoFlg', Sort.desc);
+    });
+  }
 }
 
 extension ShopQueryWhereDistinct on QueryBuilder<Shop, Shop, QDistinct> {
@@ -1496,6 +1539,12 @@ extension ShopQueryWhereDistinct on QueryBuilder<Shop, Shop, QDistinct> {
       return query.addDistinctBy(r'updatedAt');
     });
   }
+
+  QueryBuilder<Shop, Shop, QDistinct> distinctByWantToGoFlg() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'wantToGoFlg');
+    });
+  }
 }
 
 extension ShopQueryProperty on QueryBuilder<Shop, Shop, QQueryProperty> {
@@ -1556,6 +1605,12 @@ extension ShopQueryProperty on QueryBuilder<Shop, Shop, QQueryProperty> {
   QueryBuilder<Shop, DateTime, QQueryOperations> updatedAtProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'updatedAt');
+    });
+  }
+
+  QueryBuilder<Shop, bool, QQueryOperations> wantToGoFlgProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'wantToGoFlg');
     });
   }
 }

--- a/lib/view/map_page.dart
+++ b/lib/view/map_page.dart
@@ -19,6 +19,7 @@ import 'package:gohan_map/utils/map_pins.dart';
 import 'package:gohan_map/utils/safearea_utils.dart';
 import 'package:gohan_map/view/place_create_page.dart';
 import 'package:gohan_map/view/place_detail_page.dart';
+import 'package:gohan_map/view/place_post_page.dart';
 import 'package:gohan_map/view/place_search_page.dart';
 import 'package:isar/isar.dart';
 import 'package:latlong2/latlong.dart';
@@ -190,11 +191,36 @@ class MapPageState extends State<MapPage> with TickerProviderStateMixin {
                     builder: (context) {
                       return PlaceCreatePage(
                         latlng: paResult.latlng,
-                        initialShopName: paResult.name, placeId: paResult.placeId,
+                        initialShopName: paResult.name,
+                        placeId: paResult.placeId,
+                        address: paResult.address,
                       );
                     },
-                  ).then((value) {
+                  ).then((shopId) {
                     _loadAllShop();
+                    if (shopId != null) {
+                      //ピンの位置に移動する
+                      IsarUtils.getShopById(shopId).then((shop) {
+                        if (shop != null) {
+                          final latLng =
+                              LatLng(shop.shopLatitude, shop.shopLongitude);
+                          _moveToPin(latLng, deviceHeight * 0.2);
+                          //初回投稿
+                          showModalBottomSheet(
+                            barrierColor: Colors.black.withOpacity(0),
+                            isDismissible: true,
+                            context: context,
+                            isScrollControlled: true,
+                            backgroundColor: Colors.transparent,
+                            builder: (context) {
+                              return PlacePostPage(
+                                shop: shop,
+                              );
+                            },
+                          );
+                        }
+                      });
+                    }
                   });
                 }
               },
@@ -246,17 +272,17 @@ class MapPageState extends State<MapPage> with TickerProviderStateMixin {
                         tapFlgs[shop.id] = true;
                       });
                       showModalBottomSheet(
-                      barrierColor: Colors.black.withOpacity(0),
-                      isDismissible: true,
-                      isScrollControlled: true,
-                      backgroundColor: Colors.transparent,
-                      context: context,
-                      builder: (context) {
-                        return PlaceDetailPage(
-                          id: shop.id,
-                        ); //飲食店の詳細画面
-                      },
-                    ).then((value) => _onModalPop(value, shop.id));
+                        barrierColor: Colors.black.withOpacity(0),
+                        isDismissible: true,
+                        isScrollControlled: true,
+                        backgroundColor: Colors.transparent,
+                        context: context,
+                        builder: (context) {
+                          return PlaceDetailPage(
+                            id: shop.id,
+                          ); //飲食店の詳細画面
+                        },
+                      ).then((value) => _onModalPop(value, shop.id));
                     });
                   }
                 },

--- a/lib/view/place_create_page.dart
+++ b/lib/view/place_create_page.dart
@@ -262,59 +262,5 @@ class _PlaceCreatePageState extends State<PlaceCreatePage> {
     });
   }
 
-  // //緯度経度から住所を取得する
-  // Future<String> _getAddressFromLatLng(LatLng latLng) async {
-  //   const String apiKey = String.fromEnvironment("YAHOO_API_KEY");
-  //   final String apiUrl =
-  //       'https://map.yahooapis.jp/geoapi/V1/reverseGeoCoder?lat=${latLng.latitude}&lon=${latLng.longitude}&appid=$apiKey&output=json';
-  //   final response = await http.get(Uri.parse(apiUrl));
-  //   if (response.statusCode == 200) {
-  //     final responseData = json.decode(response.body);
-  //     final address = responseData['Feature'][0]['Property']['Address'];
-  //     return address;
-  //   } else {
-  //     return '住所を取得できませんでした';
-  //   }
-  // }
 }
 
-// //店名を入力するWidget
-// class _ShopNameTextField extends StatelessWidget {
-//   final Function(String) onChanged;
-//   final String? initialShopName;
-
-//   const _ShopNameTextField({
-//     Key? key,
-//     required this.onChanged,
-//     this.initialShopName,
-//   }) : super(key: key);
-
-//   @override
-//   Widget build(BuildContext context) {
-//     //角丸,白いぬりつぶし,枠線なし
-//     return Flexible(
-//       child: TextFormField(
-//         decoration: InputDecoration(
-//           hintText: '店名を入力',
-//           filled: true,
-//           fillColor: AppColors.whiteColor,
-//           contentPadding: const EdgeInsets.all(16),
-//           enabledBorder: OutlineInputBorder(
-//             borderSide: const BorderSide(
-//               color: AppColors.whiteColor,
-//             ),
-//             borderRadius: BorderRadius.circular(12),
-//           ),
-//           focusedBorder: OutlineInputBorder(
-//             borderSide: const BorderSide(
-//               color: AppColors.whiteColor,
-//             ),
-//             borderRadius: BorderRadius.circular(12),
-//           ),
-//         ),
-//         initialValue: initialShopName,
-//         onChanged: onChanged,
-//       ),
-//     );
-//   }
-// }

--- a/lib/view/place_detail_page.dart
+++ b/lib/view/place_detail_page.dart
@@ -82,25 +82,24 @@ class _PlaceDetailPageState extends State<PlaceDetailPage> {
                 ),
               ),
               Positioned(
-                  right: 12,
-                  top: 12,
-                  child: SizedBox(
-                    height: 30,
-                    width: 30,
-                    child: IconButton(
-                      padding: const EdgeInsets.fromLTRB(0, 0, 12, 12), //44px確保
-                      icon: Icon(
-                        Icons.cancel_outlined,
-                        color: Colors.grey[300],
-
-                        size: 32,
-                      ),
-                      onPressed: () {
-                        Navigator.pop(context); //前の画面に戻る
-                      },
+                right: 12,
+                top: 12,
+                child: SizedBox(
+                  height: 30,
+                  width: 30,
+                  child: IconButton(
+                    padding: const EdgeInsets.fromLTRB(0, 0, 12, 12), //44px確保
+                    icon: Icon(
+                      Icons.cancel_outlined,
+                      color: Colors.grey[300],
+                      size: 32,
                     ),
+                    onPressed: () {
+                      Navigator.pop(context); //前の画面に戻る
+                    },
                   ),
                 ),
+              ),
             ],
           ),
           const SizedBox(
@@ -141,28 +140,29 @@ class _PlaceDetailPageState extends State<PlaceDetailPage> {
                       ],
                     ),
                     if (shopTimeline?.isNotEmpty ?? false)
-                    //星の数
-                    Padding(
-                      padding:
-                          const EdgeInsets.only(top: 8, bottom: 8, left: 2),
-                      child: Row(children: [
-                        Text(
-                          ((aveStar*100).floor()/100.0).toString(),
-                          style: const TextStyle(color: Colors.black38),
-                        ),
-                        const Padding(
-                          padding: EdgeInsets.only(right: 4),
-                        ),
-                        IgnorePointer(
-                          ignoring: true,
-                          child: AppRatingBar(
-                            initialRating: aveStar-0.24,//星の数の表示が正しくない不具合を対処
-                            onRatingUpdate: (rating) {},
-                            itemSize: 20,
+                      //星の数
+                      Padding(
+                        padding:
+                            const EdgeInsets.only(top: 8, bottom: 8, left: 2),
+                        child: Row(children: [
+                          Text(
+                            ((aveStar * 100).floor() / 100.0).toString(),
+                            style: const TextStyle(color: Colors.black38),
                           ),
-                        )
-                      ]),
-                    ),
+                          const Padding(
+                            padding: EdgeInsets.only(right: 4),
+                          ),
+                          IgnorePointer(
+                            ignoring: true,
+                            child: AppRatingBar(
+                              initialRating:
+                                  aveStar - 0.24, //星の数の表示が正しくない不具合を対処
+                              onRatingUpdate: (rating) {},
+                              itemSize: 20,
+                            ),
+                          )
+                        ]),
+                      ),
                     Padding(
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         child: Row(
@@ -240,11 +240,15 @@ class _PlaceDetailPageState extends State<PlaceDetailPage> {
                                       ); //ご飯投稿
                                     },
                                   ).then((value) {
-                                    IsarUtils.getTimelinesByShopId(
-                                            selectedShop!.id)
-                                        .then((timeline) {
+                                    Future(() async {
+                                      final timeline =
+                                          await IsarUtils.getTimelinesByShopId(
+                                              selectedShop!.id);
+                                      final shop = await IsarUtils.getShopById(
+                                          selectedShop!.id);
                                       setState(() {
                                         shopTimeline = timeline;
+                                        selectedShop = shop;
                                         aveStar = calcAveStar(timeline);
                                       });
                                     });

--- a/lib/view/place_post_page.dart
+++ b/lib/view/place_post_page.dart
@@ -204,7 +204,7 @@ class _PlacePostPageState extends State<PlacePostPage> {
             title: const Text('投稿の入力がありません'),
             actions: [
               CupertinoDialogAction(
-                child: const Text('Close'),
+                child: const Text('閉じる'),
                 onPressed: () {
                   Navigator.pop(context);
                 },
@@ -216,14 +216,33 @@ class _PlacePostPageState extends State<PlacePostPage> {
       return;
     }
 
-    if (widget.timeline != null) {
-      _updateTimeline();
-    } else {
-      _addToDB();
-    }
+    
+    Future(() async {
+      //wantToGoフラグがTrueの場合はFalseに変更
+      if (widget.shop.wantToGoFlg) {
+        final shop = Shop()
+          ..id = widget.shop.id
+          ..shopName = widget.shop.shopName
+          ..shopAddress = widget.shop.shopAddress
+          ..googleMapURL = widget.shop.googleMapURL
+          ..googlePlaceId = widget.shop.googlePlaceId
+          ..shopLatitude = widget.shop.shopLatitude
+          ..shopLongitude = widget.shop.shopLongitude
+          ..shopMapIconKind = widget.shop.shopMapIconKind
+          ..wantToGoFlg = false
+          ..createdAt = widget.shop.createdAt
+          ..updatedAt = DateTime.now();
+        await IsarUtils.createShop(shop);
+      }
+      if (widget.timeline != null) {
+        _updateTimeline();
+      } else {
+        _addToDB();
+      }
+    });
   }
 
-  //DBに店を新規登録
+  //DBに投稿を追加
   Future<void> _addToDB() async {
     String? imagePath = await saveImageFile(image);
     final timeline = Timeline()
@@ -240,12 +259,12 @@ class _PlacePostPageState extends State<PlacePostPage> {
     if (context.mounted) {
       //振動
       Haptic.onSuccess();
-      Navigator.pop(context, "update");
+      Navigator.pop(context);
       return;
     }
   }
 
-  //DBに店を新規登録
+  //DBの投稿を更新
   Future<void> _updateTimeline() async {
     String? imagePath = await saveImageFile(image);
     final timeline = Timeline()
@@ -263,7 +282,7 @@ class _PlacePostPageState extends State<PlacePostPage> {
     if (context.mounted) {
       //振動
       Haptic.onSuccess();
-      Navigator.pop(context, "update");
+      Navigator.pop(context);
       return;
     }
   }

--- a/lib/view/place_update_page.dart
+++ b/lib/view/place_update_page.dart
@@ -1,19 +1,14 @@
-import 'dart:convert';
 
 import 'package:flutter/Cupertino.dart';
 import 'package:flutter/Material.dart';
 import 'package:flutter_haptic/haptic.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:gohan_map/collections/shop.dart';
-import 'package:gohan_map/component/app_rating_bar.dart';
 import 'package:gohan_map/utils/isar_utils.dart';
 import 'package:gohan_map/utils/map_pins.dart';
-import 'package:http/http.dart' as http;
 
 import 'package:gohan_map/colors/app_colors.dart';
 import 'package:gohan_map/component/app_modal.dart';
-import 'package:latlong2/latlong.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 // 飲食店の更新画面
 class PlaceUpdatePage extends StatefulWidget {
@@ -30,26 +25,26 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
   @override
   void initState() {
     super.initState();
-    defaultLatLng = LatLng(widget.shop.shopLatitude, widget.shop.shopLongitude);
-    shopName = widget.shop.shopName;
-    shopLatitude = widget.shop.shopLatitude;
-    shopLongitude = widget.shop.shopLongitude;
     shopMapIconKind = widget.shop.shopMapIconKind;
+    wantToGoFlg = widget.shop.wantToGoFlg;
+    Future(() async {
+      // 一度でも行ったことがあるか
+      haveEverBeen = await IsarUtils.getTimelinesByShopId(widget.shop.id)
+          .then((value) => value.isNotEmpty);
+      setState(() {
+        // reload
+      });
+    });
   }
 
   MapController mapController = MapController();
-  late LatLng defaultLatLng;
-
-  late String shopName;
-  late double shopLatitude;
-  late double shopLongitude;
   late String shopMapIconKind;
+  late bool wantToGoFlg;
   bool isValidating = false;
+  bool haveEverBeen = true;
 
   @override
   Widget build(BuildContext context) {
-    final String? pinImgPath = findPinByKind(shopMapIconKind)?.pinImagePath;
-
     return AppModal(
       initialChildSize: 0.9,
       child: Padding(
@@ -57,157 +52,34 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-              //飲食店名
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
+            //飲食店名
+            Text(
+              widget.shop.shopName,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            //住所
+            const Padding(
+              padding: EdgeInsets.fromLTRB(0, 16, 0, 4),
+              child: Row(
                 children: [
-                  const Expanded(
-                      child: Text(
-                    "飲食店編集",
+                  Icon(
+                    Icons.place,
+                    color: Colors.blue,
+                  ),
+                  Padding(padding: EdgeInsets.only(right: 5)),
+                  Text(
+                    '住所',
                     style: TextStyle(
-                      fontSize: 24,
+                      fontSize: 16,
                       fontWeight: FontWeight.bold,
                     ),
-                  )),
-                  const SizedBox(width: 24),
-                  SizedBox(
-                    height: 30,
-                    width: 30,
-                    child: IconButton(
-                      padding: const EdgeInsets.all(0),
-                      icon: const Icon(
-                        Icons.cancel_outlined,
-                        size: 32,
-                      ),
-                      onPressed: () {
-                        Navigator.pop(context); //前の画面に戻る
-                      },
-                    ),
-                  ),
+                  )
                 ],
               ),
-            ]),
-            Padding(
-              padding: const EdgeInsets.only(top: 16),
-              child: _ShopNameTextField(
-                initialValue: shopName,
-                onChanged: (value) {
-                  setState(() {
-                    shopName = value;
-                  });
-                },
-              ),
             ),
-            //地図
-            const Padding(
-              padding: EdgeInsets.fromLTRB(0, 16, 0, 8),
-              child: Text(
-                "場所",
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-            SizedBox(
-              height: 250,
-              child: Stack(
-                children: [
-                  Container(
-                    decoration: BoxDecoration(
-                      border: Border.all(
-                        color: AppColors.greyColor,
-                      ),
-                    ),
-                    child: FutureBuilder(
-                      future: SharedPreferences.getInstance(),
-                      builder: (context, snapshot) {
-                        if (snapshot.hasData) {
-                          final pref = snapshot.data as SharedPreferences;
-                          final String currentTileURL =
-                              pref.getString("currentTileURL") ??
-            "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png";
-                          return FlutterMap(
-                            mapController: mapController,
-                            options: MapOptions(
-                              center: defaultLatLng, //東京駅
-                              zoom: 15.0,
-                              maxZoom: 17.0,
-                              minZoom: 3.0,
-                              onPositionChanged: (position, hasGesture) {
-                                if (position.center != null) {
-                                  setState(() {
-                                    shopLatitude = position.center!.latitude;
-                                    shopLongitude = position.center!.longitude;
-                                  });
-                                }
-                              },
-                              onTap: (tapPosition, latlng) {
-                                _animatedMapMove(latlng, 15, 500);
-                              },
-                            ),
-                            children: [
-                              TileLayer(
-                                urlTemplate: currentTileURL,
-                              ),
-                            ],
-                          );
-                        } else {
-                          return const Center(
-                            child: CircularProgressIndicator(),
-                          );
-                        }
-                      },
-                    ),
-                  ),
-
-                  //上にimages/pin.pngを重ねる。ただしピンの下端がSizedBoxの中心になるようにする。
-                  Align(
-                    alignment: Alignment.center,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        SizedBox(
-                          height: 35,
-                          width: 35,
-                          child: Image.asset(pinImgPath ?? "images/pin.png"),
-                        ),
-                        const SizedBox(height: 35),
-                      ],
-                    ),
-                  ),
-                  //右下に戻すボタンを表示
-                  if (defaultLatLng.latitude != shopLatitude ||
-                      defaultLatLng.longitude != shopLongitude)
-                    Align(
-                      alignment: Alignment.bottomRight,
-                      child: Padding(
-                        padding: const EdgeInsets.only(bottom: 16, right: 16),
-                        child: SizedBox(
-                          height: 44,
-                          width: 44,
-                          child: TextButton(
-                            style: TextButton.styleFrom(
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(10),
-                              ),
-                              foregroundColor: AppColors.blackTextColor,
-                              backgroundColor: AppColors.whiteColor,
-                            ),
-                            onPressed: () {
-                              _animatedMapMove(defaultLatLng, 15, 500);
-                            },
-                            child: const Icon(
-                              Icons.replay_outlined,
-                              color: AppColors.primaryColor,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                ],
-              ),
+            Text(
+              widget.shop.shopAddress,
+              style: const TextStyle(fontSize: 16),
             ),
             // ピンの種類
             const Padding(
@@ -247,6 +119,35 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
               },
               value: shopMapIconKind,
             ),
+            // 行きたいフラグ
+            const Padding(
+              padding: EdgeInsets.fromLTRB(0, 16, 0, 4),
+              child: Text(
+                '訪問状況',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            Opacity(
+              opacity: (haveEverBeen) ? 0.5 : 1,
+              child: CupertinoSlidingSegmentedControl(
+                groupValue: wantToGoFlg,
+                children: const <bool, Widget>{
+                  true: Text('行ってみたい'),
+                  false: Text('行った'),
+                },
+                onValueChanged: (bool? value) {
+                  if (value == null || haveEverBeen) return;
+                  setState(() {
+                    wantToGoFlg = value;
+                  });
+                },
+              ),
+            ),
+            if(haveEverBeen)
+            const Text("記録済みのため、行ってみたいへの変更はできません。", style: TextStyle(color: Colors.grey, fontSize: 12),),
             //決定ボタン
             Container(
               width: double.infinity,
@@ -322,73 +223,20 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
   bool isDeleted = false;
 //決定ボタンを押した時の処理
   Future<void> _onTapComfirm(BuildContext context) async {
-    setState(() {
-      isValidating = true;
-    });
-    //住所取得
-    final shopAddress =
-        await _getAddressFromLatLng(LatLng(shopLatitude, shopLongitude));
-    //バリデーション
-    if (context.mounted) {
-      if (shopName.isEmpty) {
-        showCupertinoDialog(
-          context: context,
-          builder: (context) {
-            return CupertinoAlertDialog(
-              title: const Text('店名を入力してください'),
-              content: const Text('店を登録するためには、店名の入力が必要です。'),
-              actions: [
-                CupertinoDialogAction(
-                  child: const Text('OK'),
-                  onPressed: () async {
-                    Navigator.pop(context);
-                  },
-                ),
-              ],
-            );
-          },
-        );
-        setState(() {
-          isValidating = false;
-        });
-        return;
-      } else if (shopAddress.isEmpty || shopAddress == "住所を取得できませんでした") {
-        showCupertinoDialog(
-          context: context,
-          builder: (context) {
-            return CupertinoAlertDialog(
-              title: const Text('住所を取得できません'),
-              content: const Text('インターネットへの接続状況をご確認ください。'),
-              actions: [
-                CupertinoDialogAction(
-                  child: const Text('OK'),
-                  onPressed: () async {
-                    Navigator.pop(context);
-                  },
-                ),
-              ],
-            );
-          },
-        );
-        setState(() {
-          isValidating = false;
-        });
-        return;
-      }
-      _updateDB(shopAddress);
-    }
+    _updateDB();
   }
 
-  Future<void> _updateDB(String shopAddress) async {
+  Future<void> _updateDB() async {
     final shop = Shop()
       ..id = widget.shop.id
-      ..shopName = shopName
-      ..shopAddress = shopAddress
+      ..shopName = widget.shop.shopName
+      ..shopAddress = widget.shop.shopAddress
       ..googleMapURL = null
       ..googlePlaceId = widget.shop.googlePlaceId
-      ..shopLatitude = shopLatitude
-      ..shopLongitude = shopLongitude
+      ..shopLatitude = widget.shop.shopLatitude
+      ..shopLongitude = widget.shop.shopLongitude
       ..shopMapIconKind = shopMapIconKind
+      ..wantToGoFlg = wantToGoFlg
       ..createdAt = widget.shop.createdAt
       ..updatedAt = DateTime.now();
     await IsarUtils.createShop(shop);
@@ -440,91 +288,9 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
             ));
       },
     ).then((value) {
-      if (isDeleted){
+      if (isDeleted) {
         Navigator.of(context).popUntil((route) => route.isFirst);
       }
     });
-  }
-
-  void _animatedMapMove(LatLng destLocation, double destZoom, int millsec) {
-    final latTween = Tween<double>(
-        begin: mapController.center.latitude, end: destLocation.latitude);
-    final lngTween = Tween<double>(
-        begin: mapController.center.longitude, end: destLocation.longitude);
-    final zoomTween = Tween<double>(begin: mapController.zoom, end: destZoom);
-    final controller = AnimationController(
-        duration: Duration(milliseconds: millsec), vsync: this);
-    final Animation<double> animation =
-        CurvedAnimation(parent: controller, curve: Curves.fastOutSlowIn);
-    controller.addListener(() {
-      mapController.move(
-          LatLng(latTween.evaluate(animation), lngTween.evaluate(animation)),
-          zoomTween.evaluate(animation));
-    });
-    animation.addStatusListener((status) {
-      if (status == AnimationStatus.completed) {
-        controller.dispose();
-      } else if (status == AnimationStatus.dismissed) {
-        controller.dispose();
-      }
-    });
-    controller.forward();
-  }
-
-  //緯度経度から住所を取得する
-  Future<String> _getAddressFromLatLng(LatLng latLng) async {
-    const String apiKey = String.fromEnvironment("YAHOO_API_KEY");
-    final String apiUrl =
-        'https://map.yahooapis.jp/geoapi/V1/reverseGeoCoder?lat=${latLng.latitude}&lon=${latLng.longitude}&appid=$apiKey&output=json';
-    try {
-      final response = await http
-          .get(Uri.parse(apiUrl))
-          .timeout(const Duration(seconds: 10));
-      if (response.statusCode == 200) {
-        final responseData = json.decode(response.body);
-        final address = responseData['Feature'][0]['Property']['Address'];
-        return address;
-      } else {
-        return '住所を取得できませんでした';
-      }
-    } catch (e) {
-      return '住所を取得できませんでした';
-    }
-  }
-}
-
-class _ShopNameTextField extends StatelessWidget {
-  const _ShopNameTextField({
-    Key? key,
-    this.initialValue,
-    required this.onChanged,
-  }) : super(key: key);
-  final Function(String) onChanged;
-  final String? initialValue;
-  @override
-  Widget build(BuildContext context) {
-    //角丸,白いぬりつぶし,枠線なし
-    return TextFormField(
-      initialValue: initialValue,
-      decoration: InputDecoration(
-        hintText: '店名を入力',
-        filled: true,
-        fillColor: AppColors.whiteColor,
-        contentPadding: const EdgeInsets.all(16),
-        enabledBorder: OutlineInputBorder(
-          borderSide: const BorderSide(
-            color: AppColors.whiteColor,
-          ),
-          borderRadius: BorderRadius.circular(12),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderSide: const BorderSide(
-            color: AppColors.whiteColor,
-          ),
-          borderRadius: BorderRadius.circular(12),
-        ),
-      ),
-      onChanged: onChanged,
-    );
   }
 }


### PR DESCRIPTION
## 実装内容
行ってみたい機能を実装し、お店投稿・編集画面を改修しました

 - DBのshopテーブルに、wantToGoFlg:boolを追加
 - お店登録時に"行ってみたい店舗として登録" ボタンを追加
   - これを押すとwantToGoFlgがtrueになって登録される
 - お店登録時に"店舗を登録" ボタンを押すと、wantToGoFlgがfalseになって登録される。その後、食事の記録(投稿)もするかを聞くAlertを出す
   - 今までは同じ画面だったお店登録モーダルと初回投稿モーダルを分けている
 - 住所取得にYahooAPIを使うのでは無くGoogleMapの情報を使うように変更
   - この変更により、YahooAPIは不要になった
 - お店編集画面を修正(処理が結構変わった)
    - 削除した項目
        - 店名
        - 店の場所
    - 追加した項目
        - 行ってみたい↔️行った
           - 投稿が1件以上ある場合は、"行った"しか選択できない

## 実装していない内容
- wantToGoFlgによってピンのデザインを変える要素

## 確認してほしい要素
 - お店に投稿を行ったタイミングで”行ってみたい”が"行った"に変わること
 - 投稿が1件以上ある場合は、"行った"しか選択できないこと