### PR TITLE
検索ページを改修

### DIFF
--- a/lib/collections/search_history.dart
+++ b/lib/collections/search_history.dart
@@ -1,16 +1,13 @@
 import 'package:isar/isar.dart';
 
-part 'shop.g.dart';
+part 'search_history.g.dart';
 
 @Collection()
-class Shop {
+class SearchHistory {
   Id id = Isar.autoIncrement;
-
-  late String googlePlaceId;
-  late String shopName;
-  late String shopAddress;
-  late String shopMapIconKind;
-  late bool wantToGoFlg;
+  late String name;
+  late String placeId;
+  late String address;
   late double shopLatitude;
   late double shopLongitude;
   late DateTime createdAt;

--- a/lib/collections/search_history.dart
+++ b/lib/collections/search_history.dart
@@ -8,8 +8,8 @@ class SearchHistory {
   late String name;
   late String placeId;
   late String address;
-  late double shopLatitude;
-  late double shopLongitude;
+  late double latitude;
+  late double longitude;
   late DateTime createdAt;
   late DateTime updatedAt;
 }

--- a/lib/collections/search_history.g.dart
+++ b/lib/collections/search_history.g.dart
@@ -27,25 +27,25 @@ const SearchHistorySchema = CollectionSchema(
       name: r'createdAt',
       type: IsarType.dateTime,
     ),
-    r'name': PropertySchema(
+    r'latitude': PropertySchema(
       id: 2,
+      name: r'latitude',
+      type: IsarType.double,
+    ),
+    r'longitude': PropertySchema(
+      id: 3,
+      name: r'longitude',
+      type: IsarType.double,
+    ),
+    r'name': PropertySchema(
+      id: 4,
       name: r'name',
       type: IsarType.string,
     ),
     r'placeId': PropertySchema(
-      id: 3,
+      id: 5,
       name: r'placeId',
       type: IsarType.string,
-    ),
-    r'shopLatitude': PropertySchema(
-      id: 4,
-      name: r'shopLatitude',
-      type: IsarType.double,
-    ),
-    r'shopLongitude': PropertySchema(
-      id: 5,
-      name: r'shopLongitude',
-      type: IsarType.double,
     ),
     r'updatedAt': PropertySchema(
       id: 6,
@@ -87,10 +87,10 @@ void _searchHistorySerialize(
 ) {
   writer.writeString(offsets[0], object.address);
   writer.writeDateTime(offsets[1], object.createdAt);
-  writer.writeString(offsets[2], object.name);
-  writer.writeString(offsets[3], object.placeId);
-  writer.writeDouble(offsets[4], object.shopLatitude);
-  writer.writeDouble(offsets[5], object.shopLongitude);
+  writer.writeDouble(offsets[2], object.latitude);
+  writer.writeDouble(offsets[3], object.longitude);
+  writer.writeString(offsets[4], object.name);
+  writer.writeString(offsets[5], object.placeId);
   writer.writeDateTime(offsets[6], object.updatedAt);
 }
 
@@ -104,10 +104,10 @@ SearchHistory _searchHistoryDeserialize(
   object.address = reader.readString(offsets[0]);
   object.createdAt = reader.readDateTime(offsets[1]);
   object.id = id;
-  object.name = reader.readString(offsets[2]);
-  object.placeId = reader.readString(offsets[3]);
-  object.shopLatitude = reader.readDouble(offsets[4]);
-  object.shopLongitude = reader.readDouble(offsets[5]);
+  object.latitude = reader.readDouble(offsets[2]);
+  object.longitude = reader.readDouble(offsets[3]);
+  object.name = reader.readString(offsets[4]);
+  object.placeId = reader.readString(offsets[5]);
   object.updatedAt = reader.readDateTime(offsets[6]);
   return object;
 }
@@ -124,13 +124,13 @@ P _searchHistoryDeserializeProp<P>(
     case 1:
       return (reader.readDateTime(offset)) as P;
     case 2:
-      return (reader.readString(offset)) as P;
+      return (reader.readDouble(offset)) as P;
     case 3:
-      return (reader.readString(offset)) as P;
+      return (reader.readDouble(offset)) as P;
     case 4:
-      return (reader.readDouble(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 5:
-      return (reader.readDouble(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 6:
       return (reader.readDateTime(offset)) as P;
     default:
@@ -480,6 +480,138 @@ extension SearchHistoryQueryFilter
     });
   }
 
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      latitudeEqualTo(
+    double value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'latitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      latitudeGreaterThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'latitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      latitudeLessThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'latitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      latitudeBetween(
+    double lower,
+    double upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'latitude',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      longitudeEqualTo(
+    double value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'longitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      longitudeGreaterThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'longitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      longitudeLessThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'longitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      longitudeBetween(
+    double lower,
+    double upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'longitude',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
   QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition> nameEqualTo(
     String value, {
     bool caseSensitive = true,
@@ -752,138 +884,6 @@ extension SearchHistoryQueryFilter
   }
 
   QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
-      shopLatitudeEqualTo(
-    double value, {
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.equalTo(
-        property: r'shopLatitude',
-        value: value,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
-      shopLatitudeGreaterThan(
-    double value, {
-    bool include = false,
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.greaterThan(
-        include: include,
-        property: r'shopLatitude',
-        value: value,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
-      shopLatitudeLessThan(
-    double value, {
-    bool include = false,
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.lessThan(
-        include: include,
-        property: r'shopLatitude',
-        value: value,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
-      shopLatitudeBetween(
-    double lower,
-    double upper, {
-    bool includeLower = true,
-    bool includeUpper = true,
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.between(
-        property: r'shopLatitude',
-        lower: lower,
-        includeLower: includeLower,
-        upper: upper,
-        includeUpper: includeUpper,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
-      shopLongitudeEqualTo(
-    double value, {
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.equalTo(
-        property: r'shopLongitude',
-        value: value,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
-      shopLongitudeGreaterThan(
-    double value, {
-    bool include = false,
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.greaterThan(
-        include: include,
-        property: r'shopLongitude',
-        value: value,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
-      shopLongitudeLessThan(
-    double value, {
-    bool include = false,
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.lessThan(
-        include: include,
-        property: r'shopLongitude',
-        value: value,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
-      shopLongitudeBetween(
-    double lower,
-    double upper, {
-    bool includeLower = true,
-    bool includeUpper = true,
-    double epsilon = Query.epsilon,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.between(
-        property: r'shopLongitude',
-        lower: lower,
-        includeLower: includeLower,
-        upper: upper,
-        includeUpper: includeUpper,
-        epsilon: epsilon,
-      ));
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
       updatedAtEqualTo(DateTime value) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.equalTo(
@@ -973,6 +973,32 @@ extension SearchHistoryQuerySortBy
     });
   }
 
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByLatitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'latitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      sortByLatitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'latitude', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByLongitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      sortByLongitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longitude', Sort.desc);
+    });
+  }
+
   QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByName() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'name', Sort.asc);
@@ -994,34 +1020,6 @@ extension SearchHistoryQuerySortBy
   QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByPlaceIdDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'placeId', Sort.desc);
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
-      sortByShopLatitude() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'shopLatitude', Sort.asc);
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
-      sortByShopLatitudeDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'shopLatitude', Sort.desc);
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
-      sortByShopLongitude() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'shopLongitude', Sort.asc);
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
-      sortByShopLongitudeDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'shopLongitude', Sort.desc);
     });
   }
 
@@ -1078,6 +1076,32 @@ extension SearchHistoryQuerySortThenBy
     });
   }
 
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByLatitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'latitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      thenByLatitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'latitude', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByLongitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      thenByLongitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longitude', Sort.desc);
+    });
+  }
+
   QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByName() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'name', Sort.asc);
@@ -1099,34 +1123,6 @@ extension SearchHistoryQuerySortThenBy
   QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByPlaceIdDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'placeId', Sort.desc);
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
-      thenByShopLatitude() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'shopLatitude', Sort.asc);
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
-      thenByShopLatitudeDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'shopLatitude', Sort.desc);
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
-      thenByShopLongitude() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'shopLongitude', Sort.asc);
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
-      thenByShopLongitudeDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'shopLongitude', Sort.desc);
     });
   }
 
@@ -1159,6 +1155,18 @@ extension SearchHistoryQueryWhereDistinct
     });
   }
 
+  QueryBuilder<SearchHistory, SearchHistory, QDistinct> distinctByLatitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'latitude');
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QDistinct> distinctByLongitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'longitude');
+    });
+  }
+
   QueryBuilder<SearchHistory, SearchHistory, QDistinct> distinctByName(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -1170,20 +1178,6 @@ extension SearchHistoryQueryWhereDistinct
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'placeId', caseSensitive: caseSensitive);
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QDistinct>
-      distinctByShopLatitude() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addDistinctBy(r'shopLatitude');
-    });
-  }
-
-  QueryBuilder<SearchHistory, SearchHistory, QDistinct>
-      distinctByShopLongitude() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addDistinctBy(r'shopLongitude');
     });
   }
 
@@ -1214,6 +1208,18 @@ extension SearchHistoryQueryProperty
     });
   }
 
+  QueryBuilder<SearchHistory, double, QQueryOperations> latitudeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'latitude');
+    });
+  }
+
+  QueryBuilder<SearchHistory, double, QQueryOperations> longitudeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'longitude');
+    });
+  }
+
   QueryBuilder<SearchHistory, String, QQueryOperations> nameProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'name');
@@ -1223,19 +1229,6 @@ extension SearchHistoryQueryProperty
   QueryBuilder<SearchHistory, String, QQueryOperations> placeIdProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'placeId');
-    });
-  }
-
-  QueryBuilder<SearchHistory, double, QQueryOperations> shopLatitudeProperty() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addPropertyName(r'shopLatitude');
-    });
-  }
-
-  QueryBuilder<SearchHistory, double, QQueryOperations>
-      shopLongitudeProperty() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addPropertyName(r'shopLongitude');
     });
   }
 

--- a/lib/collections/search_history.g.dart
+++ b/lib/collections/search_history.g.dart
@@ -1,0 +1,1247 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'search_history.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetSearchHistoryCollection on Isar {
+  IsarCollection<SearchHistory> get searchHistorys => this.collection();
+}
+
+const SearchHistorySchema = CollectionSchema(
+  name: r'SearchHistory',
+  id: -4204570823138025228,
+  properties: {
+    r'address': PropertySchema(
+      id: 0,
+      name: r'address',
+      type: IsarType.string,
+    ),
+    r'createdAt': PropertySchema(
+      id: 1,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'name': PropertySchema(
+      id: 2,
+      name: r'name',
+      type: IsarType.string,
+    ),
+    r'placeId': PropertySchema(
+      id: 3,
+      name: r'placeId',
+      type: IsarType.string,
+    ),
+    r'shopLatitude': PropertySchema(
+      id: 4,
+      name: r'shopLatitude',
+      type: IsarType.double,
+    ),
+    r'shopLongitude': PropertySchema(
+      id: 5,
+      name: r'shopLongitude',
+      type: IsarType.double,
+    ),
+    r'updatedAt': PropertySchema(
+      id: 6,
+      name: r'updatedAt',
+      type: IsarType.dateTime,
+    )
+  },
+  estimateSize: _searchHistoryEstimateSize,
+  serialize: _searchHistorySerialize,
+  deserialize: _searchHistoryDeserialize,
+  deserializeProp: _searchHistoryDeserializeProp,
+  idName: r'id',
+  indexes: {},
+  links: {},
+  embeddedSchemas: {},
+  getId: _searchHistoryGetId,
+  getLinks: _searchHistoryGetLinks,
+  attach: _searchHistoryAttach,
+  version: '3.1.0+1',
+);
+
+int _searchHistoryEstimateSize(
+  SearchHistory object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.address.length * 3;
+  bytesCount += 3 + object.name.length * 3;
+  bytesCount += 3 + object.placeId.length * 3;
+  return bytesCount;
+}
+
+void _searchHistorySerialize(
+  SearchHistory object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.address);
+  writer.writeDateTime(offsets[1], object.createdAt);
+  writer.writeString(offsets[2], object.name);
+  writer.writeString(offsets[3], object.placeId);
+  writer.writeDouble(offsets[4], object.shopLatitude);
+  writer.writeDouble(offsets[5], object.shopLongitude);
+  writer.writeDateTime(offsets[6], object.updatedAt);
+}
+
+SearchHistory _searchHistoryDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = SearchHistory();
+  object.address = reader.readString(offsets[0]);
+  object.createdAt = reader.readDateTime(offsets[1]);
+  object.id = id;
+  object.name = reader.readString(offsets[2]);
+  object.placeId = reader.readString(offsets[3]);
+  object.shopLatitude = reader.readDouble(offsets[4]);
+  object.shopLongitude = reader.readDouble(offsets[5]);
+  object.updatedAt = reader.readDateTime(offsets[6]);
+  return object;
+}
+
+P _searchHistoryDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readString(offset)) as P;
+    case 1:
+      return (reader.readDateTime(offset)) as P;
+    case 2:
+      return (reader.readString(offset)) as P;
+    case 3:
+      return (reader.readString(offset)) as P;
+    case 4:
+      return (reader.readDouble(offset)) as P;
+    case 5:
+      return (reader.readDouble(offset)) as P;
+    case 6:
+      return (reader.readDateTime(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _searchHistoryGetId(SearchHistory object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _searchHistoryGetLinks(SearchHistory object) {
+  return [];
+}
+
+void _searchHistoryAttach(
+    IsarCollection<dynamic> col, Id id, SearchHistory object) {
+  object.id = id;
+}
+
+extension SearchHistoryQueryWhereSort
+    on QueryBuilder<SearchHistory, SearchHistory, QWhere> {
+  QueryBuilder<SearchHistory, SearchHistory, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension SearchHistoryQueryWhere
+    on QueryBuilder<SearchHistory, SearchHistory, QWhereClause> {
+  QueryBuilder<SearchHistory, SearchHistory, QAfterWhereClause> idEqualTo(
+      Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterWhereClause> idNotEqualTo(
+      Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterWhereClause> idGreaterThan(
+      Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterWhereClause> idLessThan(
+      Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension SearchHistoryQueryFilter
+    on QueryBuilder<SearchHistory, SearchHistory, QFilterCondition> {
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      addressEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'address',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      addressGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'address',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      addressLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'address',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      addressBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'address',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      addressStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'address',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      addressEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'address',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      addressContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'address',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      addressMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'address',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      addressIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'address',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      addressIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'address',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      createdAtEqualTo(DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      createdAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      createdAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      createdAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'createdAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition> idEqualTo(
+      Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition> nameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      nameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      nameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition> nameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'name',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      nameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      nameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      nameContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition> nameMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'name',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      nameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'name',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      nameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'name',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      placeIdEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'placeId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      placeIdGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'placeId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      placeIdLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'placeId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      placeIdBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'placeId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      placeIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'placeId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      placeIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'placeId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      placeIdContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'placeId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      placeIdMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'placeId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      placeIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'placeId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      placeIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'placeId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      shopLatitudeEqualTo(
+    double value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'shopLatitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      shopLatitudeGreaterThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'shopLatitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      shopLatitudeLessThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'shopLatitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      shopLatitudeBetween(
+    double lower,
+    double upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'shopLatitude',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      shopLongitudeEqualTo(
+    double value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'shopLongitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      shopLongitudeGreaterThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'shopLongitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      shopLongitudeLessThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'shopLongitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      shopLongitudeBetween(
+    double lower,
+    double upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'shopLongitude',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      updatedAtEqualTo(DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      updatedAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      updatedAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterFilterCondition>
+      updatedAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'updatedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension SearchHistoryQueryObject
+    on QueryBuilder<SearchHistory, SearchHistory, QFilterCondition> {}
+
+extension SearchHistoryQueryLinks
+    on QueryBuilder<SearchHistory, SearchHistory, QFilterCondition> {}
+
+extension SearchHistoryQuerySortBy
+    on QueryBuilder<SearchHistory, SearchHistory, QSortBy> {
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByAddress() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'address', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByAddressDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'address', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      sortByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByPlaceId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'placeId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByPlaceIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'placeId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      sortByShopLatitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shopLatitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      sortByShopLatitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shopLatitude', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      sortByShopLongitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shopLongitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      sortByShopLongitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shopLongitude', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> sortByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      sortByUpdatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.desc);
+    });
+  }
+}
+
+extension SearchHistoryQuerySortThenBy
+    on QueryBuilder<SearchHistory, SearchHistory, QSortThenBy> {
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByAddress() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'address', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByAddressDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'address', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      thenByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByPlaceId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'placeId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByPlaceIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'placeId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      thenByShopLatitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shopLatitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      thenByShopLatitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shopLatitude', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      thenByShopLongitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shopLongitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      thenByShopLongitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shopLongitude', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy> thenByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QAfterSortBy>
+      thenByUpdatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.desc);
+    });
+  }
+}
+
+extension SearchHistoryQueryWhereDistinct
+    on QueryBuilder<SearchHistory, SearchHistory, QDistinct> {
+  QueryBuilder<SearchHistory, SearchHistory, QDistinct> distinctByAddress(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'address', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QDistinct> distinctByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QDistinct> distinctByName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'name', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QDistinct> distinctByPlaceId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'placeId', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QDistinct>
+      distinctByShopLatitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'shopLatitude');
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QDistinct>
+      distinctByShopLongitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'shopLongitude');
+    });
+  }
+
+  QueryBuilder<SearchHistory, SearchHistory, QDistinct> distinctByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'updatedAt');
+    });
+  }
+}
+
+extension SearchHistoryQueryProperty
+    on QueryBuilder<SearchHistory, SearchHistory, QQueryProperty> {
+  QueryBuilder<SearchHistory, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<SearchHistory, String, QQueryOperations> addressProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'address');
+    });
+  }
+
+  QueryBuilder<SearchHistory, DateTime, QQueryOperations> createdAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<SearchHistory, String, QQueryOperations> nameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'name');
+    });
+  }
+
+  QueryBuilder<SearchHistory, String, QQueryOperations> placeIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'placeId');
+    });
+  }
+
+  QueryBuilder<SearchHistory, double, QQueryOperations> shopLatitudeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'shopLatitude');
+    });
+  }
+
+  QueryBuilder<SearchHistory, double, QQueryOperations>
+      shopLongitudeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'shopLongitude');
+    });
+  }
+
+  QueryBuilder<SearchHistory, DateTime, QQueryOperations> updatedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'updatedAt');
+    });
+  }
+}

--- a/lib/collections/shop.g.dart
+++ b/lib/collections/shop.g.dart
@@ -22,48 +22,43 @@ const ShopSchema = CollectionSchema(
       name: r'createdAt',
       type: IsarType.dateTime,
     ),
-    r'googleMapURL': PropertySchema(
-      id: 1,
-      name: r'googleMapURL',
-      type: IsarType.string,
-    ),
     r'googlePlaceId': PropertySchema(
-      id: 2,
+      id: 1,
       name: r'googlePlaceId',
       type: IsarType.string,
     ),
     r'shopAddress': PropertySchema(
-      id: 3,
+      id: 2,
       name: r'shopAddress',
       type: IsarType.string,
     ),
     r'shopLatitude': PropertySchema(
-      id: 4,
+      id: 3,
       name: r'shopLatitude',
       type: IsarType.double,
     ),
     r'shopLongitude': PropertySchema(
-      id: 5,
+      id: 4,
       name: r'shopLongitude',
       type: IsarType.double,
     ),
     r'shopMapIconKind': PropertySchema(
-      id: 6,
+      id: 5,
       name: r'shopMapIconKind',
       type: IsarType.string,
     ),
     r'shopName': PropertySchema(
-      id: 7,
+      id: 6,
       name: r'shopName',
       type: IsarType.string,
     ),
     r'updatedAt': PropertySchema(
-      id: 8,
+      id: 7,
       name: r'updatedAt',
       type: IsarType.dateTime,
     ),
     r'wantToGoFlg': PropertySchema(
-      id: 9,
+      id: 8,
       name: r'wantToGoFlg',
       type: IsarType.bool,
     )
@@ -88,12 +83,6 @@ int _shopEstimateSize(
   Map<Type, List<int>> allOffsets,
 ) {
   var bytesCount = offsets.last;
-  {
-    final value = object.googleMapURL;
-    if (value != null) {
-      bytesCount += 3 + value.length * 3;
-    }
-  }
   bytesCount += 3 + object.googlePlaceId.length * 3;
   bytesCount += 3 + object.shopAddress.length * 3;
   bytesCount += 3 + object.shopMapIconKind.length * 3;
@@ -108,15 +97,14 @@ void _shopSerialize(
   Map<Type, List<int>> allOffsets,
 ) {
   writer.writeDateTime(offsets[0], object.createdAt);
-  writer.writeString(offsets[1], object.googleMapURL);
-  writer.writeString(offsets[2], object.googlePlaceId);
-  writer.writeString(offsets[3], object.shopAddress);
-  writer.writeDouble(offsets[4], object.shopLatitude);
-  writer.writeDouble(offsets[5], object.shopLongitude);
-  writer.writeString(offsets[6], object.shopMapIconKind);
-  writer.writeString(offsets[7], object.shopName);
-  writer.writeDateTime(offsets[8], object.updatedAt);
-  writer.writeBool(offsets[9], object.wantToGoFlg);
+  writer.writeString(offsets[1], object.googlePlaceId);
+  writer.writeString(offsets[2], object.shopAddress);
+  writer.writeDouble(offsets[3], object.shopLatitude);
+  writer.writeDouble(offsets[4], object.shopLongitude);
+  writer.writeString(offsets[5], object.shopMapIconKind);
+  writer.writeString(offsets[6], object.shopName);
+  writer.writeDateTime(offsets[7], object.updatedAt);
+  writer.writeBool(offsets[8], object.wantToGoFlg);
 }
 
 Shop _shopDeserialize(
@@ -127,16 +115,15 @@ Shop _shopDeserialize(
 ) {
   final object = Shop();
   object.createdAt = reader.readDateTime(offsets[0]);
-  object.googleMapURL = reader.readStringOrNull(offsets[1]);
-  object.googlePlaceId = reader.readString(offsets[2]);
+  object.googlePlaceId = reader.readString(offsets[1]);
   object.id = id;
-  object.shopAddress = reader.readString(offsets[3]);
-  object.shopLatitude = reader.readDouble(offsets[4]);
-  object.shopLongitude = reader.readDouble(offsets[5]);
-  object.shopMapIconKind = reader.readString(offsets[6]);
-  object.shopName = reader.readString(offsets[7]);
-  object.updatedAt = reader.readDateTime(offsets[8]);
-  object.wantToGoFlg = reader.readBool(offsets[9]);
+  object.shopAddress = reader.readString(offsets[2]);
+  object.shopLatitude = reader.readDouble(offsets[3]);
+  object.shopLongitude = reader.readDouble(offsets[4]);
+  object.shopMapIconKind = reader.readString(offsets[5]);
+  object.shopName = reader.readString(offsets[6]);
+  object.updatedAt = reader.readDateTime(offsets[7]);
+  object.wantToGoFlg = reader.readBool(offsets[8]);
   return object;
 }
 
@@ -150,22 +137,20 @@ P _shopDeserializeProp<P>(
     case 0:
       return (reader.readDateTime(offset)) as P;
     case 1:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 2:
       return (reader.readString(offset)) as P;
     case 3:
-      return (reader.readString(offset)) as P;
+      return (reader.readDouble(offset)) as P;
     case 4:
       return (reader.readDouble(offset)) as P;
     case 5:
-      return (reader.readDouble(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 6:
       return (reader.readString(offset)) as P;
     case 7:
-      return (reader.readString(offset)) as P;
-    case 8:
       return (reader.readDateTime(offset)) as P;
-    case 9:
+    case 8:
       return (reader.readBool(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -309,152 +294,6 @@ extension ShopQueryFilter on QueryBuilder<Shop, Shop, QFilterCondition> {
         includeLower: includeLower,
         upper: upper,
         includeUpper: includeUpper,
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLIsNull() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(const FilterCondition.isNull(
-        property: r'googleMapURL',
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLIsNotNull() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(const FilterCondition.isNotNull(
-        property: r'googleMapURL',
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLEqualTo(
-    String? value, {
-    bool caseSensitive = true,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.equalTo(
-        property: r'googleMapURL',
-        value: value,
-        caseSensitive: caseSensitive,
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLGreaterThan(
-    String? value, {
-    bool include = false,
-    bool caseSensitive = true,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.greaterThan(
-        include: include,
-        property: r'googleMapURL',
-        value: value,
-        caseSensitive: caseSensitive,
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLLessThan(
-    String? value, {
-    bool include = false,
-    bool caseSensitive = true,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.lessThan(
-        include: include,
-        property: r'googleMapURL',
-        value: value,
-        caseSensitive: caseSensitive,
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLBetween(
-    String? lower,
-    String? upper, {
-    bool includeLower = true,
-    bool includeUpper = true,
-    bool caseSensitive = true,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.between(
-        property: r'googleMapURL',
-        lower: lower,
-        includeLower: includeLower,
-        upper: upper,
-        includeUpper: includeUpper,
-        caseSensitive: caseSensitive,
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLStartsWith(
-    String value, {
-    bool caseSensitive = true,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.startsWith(
-        property: r'googleMapURL',
-        value: value,
-        caseSensitive: caseSensitive,
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLEndsWith(
-    String value, {
-    bool caseSensitive = true,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.endsWith(
-        property: r'googleMapURL',
-        value: value,
-        caseSensitive: caseSensitive,
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLContains(
-      String value,
-      {bool caseSensitive = true}) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.contains(
-        property: r'googleMapURL',
-        value: value,
-        caseSensitive: caseSensitive,
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLMatches(
-      String pattern,
-      {bool caseSensitive = true}) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.matches(
-        property: r'googleMapURL',
-        wildcard: pattern,
-        caseSensitive: caseSensitive,
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLIsEmpty() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.equalTo(
-        property: r'googleMapURL',
-        value: '',
-      ));
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterFilterCondition> googleMapURLIsNotEmpty() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.greaterThan(
-        property: r'googleMapURL',
-        value: '',
       ));
     });
   }
@@ -1235,18 +1074,6 @@ extension ShopQuerySortBy on QueryBuilder<Shop, Shop, QSortBy> {
     });
   }
 
-  QueryBuilder<Shop, Shop, QAfterSortBy> sortByGoogleMapURL() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'googleMapURL', Sort.asc);
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterSortBy> sortByGoogleMapURLDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'googleMapURL', Sort.desc);
-    });
-  }
-
   QueryBuilder<Shop, Shop, QAfterSortBy> sortByGooglePlaceId() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'googlePlaceId', Sort.asc);
@@ -1354,18 +1181,6 @@ extension ShopQuerySortThenBy on QueryBuilder<Shop, Shop, QSortThenBy> {
   QueryBuilder<Shop, Shop, QAfterSortBy> thenByCreatedAtDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'createdAt', Sort.desc);
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterSortBy> thenByGoogleMapURL() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'googleMapURL', Sort.asc);
-    });
-  }
-
-  QueryBuilder<Shop, Shop, QAfterSortBy> thenByGoogleMapURLDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'googleMapURL', Sort.desc);
     });
   }
 
@@ -1485,13 +1300,6 @@ extension ShopQueryWhereDistinct on QueryBuilder<Shop, Shop, QDistinct> {
     });
   }
 
-  QueryBuilder<Shop, Shop, QDistinct> distinctByGoogleMapURL(
-      {bool caseSensitive = true}) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addDistinctBy(r'googleMapURL', caseSensitive: caseSensitive);
-    });
-  }
-
   QueryBuilder<Shop, Shop, QDistinct> distinctByGooglePlaceId(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -1557,12 +1365,6 @@ extension ShopQueryProperty on QueryBuilder<Shop, Shop, QQueryProperty> {
   QueryBuilder<Shop, DateTime, QQueryOperations> createdAtProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'createdAt');
-    });
-  }
-
-  QueryBuilder<Shop, String?, QQueryOperations> googleMapURLProperty() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addPropertyName(r'googleMapURL');
     });
   }
 

--- a/lib/colors/app_colors.dart
+++ b/lib/colors/app_colors.dart
@@ -9,8 +9,8 @@ class AppColors {
   static const Color redTextColor = Color(0xFFDF3030);
   static const Color searchBarColor = Color(0xFFE2DFDC);
   static const Color whiteColor = Color(0xffffffff);
-  static const Color greyDarkColor = Color(0xffa9a9a9);
-  static const Color greyColor = Color(0xffd9d9d9);
-  static const Color greyLightColor = Color(0xfff5f5f5);
+  static const Color greyDarkColor = Color(0xffa9a9a9);//テキストなど
+  static const Color greyColor = Color(0xffd9d9d9);//枠線など
+  static const Color greyLightColor = Color(0xfff5f5f5);//背景色など
   static const Color pinColor = Color.fromARGB(255, 255, 0, 0);
 }

--- a/lib/colors/app_colors.dart
+++ b/lib/colors/app_colors.dart
@@ -6,7 +6,7 @@ class AppColors {
   static const Color blackTextColor = Color(0xFF000000);
   static const Color primaryColor = Color(0xFFFC8B56);
   static const Color tabBarColor = Color(0xFFF86F35);
-  static const Color redTextColor = Color(0xFFDF3030);
+  static const Color redTextColor = Color(0xFFFF5959);
   static const Color searchBarColor = Color(0xFFE2DFDC);
   static const Color whiteColor = Color(0xffffffff);
   static const Color greyDarkColor = Color(0xffa9a9a9);//テキストなど

--- a/lib/colors/app_colors.dart
+++ b/lib/colors/app_colors.dart
@@ -9,6 +9,8 @@ class AppColors {
   static const Color redTextColor = Color(0xFFDF3030);
   static const Color searchBarColor = Color(0xFFE2DFDC);
   static const Color whiteColor = Color(0xffffffff);
+  static const Color greyDarkColor = Color(0xffa9a9a9);
   static const Color greyColor = Color(0xffd9d9d9);
+  static const Color greyLightColor = Color(0xfff5f5f5);
   static const Color pinColor = Color.fromARGB(255, 255, 0, 0);
 }

--- a/lib/component/app_map.dart
+++ b/lib/component/app_map.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_compass/flutter_compass.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:gohan_map/colors/app_colors.dart';
 import 'package:gohan_map/component/app_direction_light.dart';
-import 'package:gohan_map/view/all_post_page.dart';
 import 'package:gohan_map/view/change_map_page.dart';
 import 'package:gohan_map/view/tutorial_page.dart';
 import 'package:latlong2/latlong.dart';

--- a/lib/component/app_modal.dart
+++ b/lib/component/app_modal.dart
@@ -61,9 +61,8 @@ class _AppModalState extends State<AppModal> {
             child: Container(
               //モーダルの中身
               decoration: BoxDecoration(
-                boxShadow:const  [
-                  BoxShadow(blurRadius: 5, color: Colors.grey, spreadRadius: 0.5)
-                ],
+                boxShadow:
+                   [BoxShadow(blurRadius: 16, color: Colors.black.withOpacity(0.2))],
                 color: widget.backgroundColor,
                 borderRadius: const BorderRadius.only(
                   topLeft: Radius.circular(20.0),

--- a/lib/component/app_search_bar.dart
+++ b/lib/component/app_search_bar.dart
@@ -4,11 +4,15 @@ import 'package:gohan_map/colors/app_colors.dart';
 class AppSearchBar extends StatelessWidget {
   final Function(String)? onSubmitted;
   final Function(String)? onChanged;
+  final Function()? onPressClear;
+  final bool showBack;
   final bool autofocus;
   const AppSearchBar({
     Key? key,
     this.onSubmitted,
     this.onChanged,
+    this.onPressClear,
+    this.showBack = true,
     this.autofocus = false,
   }) : super(key: key);
 
@@ -18,28 +22,48 @@ class AppSearchBar extends StatelessWidget {
       color: Colors.transparent,
       child: Container(
         //角丸
-        height: 46,
+        height: 50,
         decoration: BoxDecoration(
-          color: AppColors.searchBarColor,
-          borderRadius: BorderRadius.circular(23),
+          color: AppColors.greyLightColor,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+            color: AppColors.greyColor,
+            width: 1,
+          ),
         ),
         padding: const EdgeInsets.symmetric(horizontal: 16),
         child: Row(
           children: [
-            const Icon(
-              Icons.search,
-              color: AppColors.blackTextColor,
-            ),
-            Expanded(
-              child: TextField(
-                autofocus: autofocus,
-                cursorColor: AppColors.blackTextColor,
-                decoration: const InputDecoration(
-                  hintText: 'Search',
-                  border: InputBorder.none,
+            if (showBack == true)
+              InkWell(
+                child: const Icon(
+                  Icons.arrow_back_ios_new_rounded,
+                  color: AppColors.blackTextColor,
                 ),
-                onSubmitted: onSubmitted,
-                onChanged: onChanged,
+                onTap: () {
+                  Navigator.pop(context);
+                },
+              ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                child: TextField(
+                  autofocus: autofocus,
+                  cursorColor: AppColors.blackTextColor,
+                  decoration: const InputDecoration(
+                    hintText: 'お店の 検索 / 登録',
+                    border: InputBorder.none,
+                  ),
+                  onSubmitted: onSubmitted,
+                  onChanged: onChanged,
+                ),
+              ),
+            ),
+            InkWell(
+              onTap: onPressClear,
+              child: const Icon(
+                Icons.close_rounded,
+                color: AppColors.blackTextColor,
               ),
             ),
           ],

--- a/lib/component/app_search_bar.dart
+++ b/lib/component/app_search_bar.dart
@@ -7,6 +7,7 @@ class AppSearchBar extends StatelessWidget {
   final Function()? onPressClear;
   final bool showBack;
   final bool autofocus;
+  final TextEditingController? controller;
   const AppSearchBar({
     Key? key,
     this.onSubmitted,
@@ -14,6 +15,7 @@ class AppSearchBar extends StatelessWidget {
     this.onPressClear,
     this.showBack = true,
     this.autofocus = false,
+    this.controller
   }) : super(key: key);
 
   @override
@@ -48,6 +50,7 @@ class AppSearchBar extends StatelessWidget {
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4.0),
                 child: TextField(
+                  controller: controller,
                   autofocus: autofocus,
                   cursorColor: AppColors.blackTextColor,
                   decoration: const InputDecoration(

--- a/lib/component/post_food_widget.dart
+++ b/lib/component/post_food_widget.dart
@@ -289,7 +289,6 @@ class _ImgSectionState extends State<_ImgSection> {
   }
 }
 
-//うまいボタン
 class _StarSection extends StatelessWidget {
   const _StarSection({
     this.initialStar,

--- a/lib/icon/app_icon_icons.dart
+++ b/lib/icon/app_icon_icons.dart
@@ -17,6 +17,8 @@
 ///         License:   SIL (https://github.com/FortAwesome/Font-Awesome/blob/master/LICENSE.txt)
 ///         Homepage:  http://fortawesome.github.com/Font-Awesome/
 ///
+// ignore_for_file: constant_identifier_names
+
 import 'package:flutter/widgets.dart';
 
 class AppIcons {

--- a/lib/utils/isar_utils.dart
+++ b/lib/utils/isar_utils.dart
@@ -41,7 +41,8 @@ class IsarUtils {
   // shopの全取得
   static Future<List<Shop>> getAllShops() async {
     await ensureInitialized();
-    final shops = await isar!.shops.where().findAll();    return shops.toList();
+    final shops = await isar!.shops.where().findAll();
+    return shops.toList();
   }
 
   // shopを条件で絞り込み検索
@@ -85,7 +86,7 @@ class IsarUtils {
     return timelines.toList();
   }
 
-    static Future<List<Timeline>> getAllTimelines() async {
+  static Future<List<Timeline>> getAllTimelines() async {
     await ensureInitialized();
     final timelines = await isar!.timelines
         .where()
@@ -95,16 +96,11 @@ class IsarUtils {
     return timelines.toList();
   }
 
-  static Future<Timeline?> getTimelineById(int id) async{
+  static Future<Timeline?> getTimelineById(int id) async {
     await ensureInitialized();
-    final timeline = await isar!.timelines
-        .where()
-        .idEqualTo(id)
-        .findFirst();
+    final timeline = await isar!.timelines.where().idEqualTo(id).findFirst();
     return timeline;
   }
-
-
 
   // timelineの作成・更新
   static Future<void> createTimeline(Timeline timeline) async {
@@ -134,9 +130,42 @@ class IsarUtils {
     });
   }
 
+  // shopの取得
   static Future<Shop?> getShopById(Id id) async {
     await ensureInitialized();
     final shop = await isar!.shops.get(id);
     return shop;
   }
+
+  //googlePlaceIdからshopを取得
+  static Future<Shop?> getShopByGooglePlaceId(String googlePlaceId) async {
+    await ensureInitialized();
+    final shop = await isar!.shops
+        .where()
+        .filter()
+        .googlePlaceIdEqualTo(googlePlaceId)
+        .findFirst();
+    return shop;
+  }
+  //   final shop = await isar!.writeTxn((isar) async {
+  //     // 'googlePlaceId'が指定したテキストであるShopレコードを検索
+  //     final shopQuery = isar.read<Shop>()
+  //         .where()
+  //         .filter()
+  //         .googlePlaceIdEqualTo(googlePlaceId)
+  //         .build();
+
+  //     final shops = await shopQuery.find();
+
+  //     if (shops.isNotEmpty) {
+  //       // 該当するレコードが存在する場合、最初の要素を返す
+  //       return shops.first;
+  //     } else {
+  //       // 該当するレコードが存在しない場合、nullを返す
+  //       return null;
+  //     }
+  //   } as Future Function());
+
+  //   return shop;
+  // }
 }

--- a/lib/view/map_page.dart
+++ b/lib/view/map_page.dart
@@ -114,7 +114,7 @@ class MapPageState extends State<MapPage> with TickerProviderStateMixin {
                     [BoxShadow(blurRadius: 16, color: Colors.black.withOpacity(0.2))],
               ),
               child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 27),
+                padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 16),
                 child: Container(
                   height: 50,
                   decoration: BoxDecoration(

--- a/lib/view/map_page.dart
+++ b/lib/view/map_page.dart
@@ -104,14 +104,14 @@ class MapPageState extends State<MapPage> with TickerProviderStateMixin {
           child: AbsorbPointer(
             child: Container(
               //モーダル風UIの中身
-              decoration: const BoxDecoration(
+              decoration: BoxDecoration(
                 color: AppColors.whiteColor,
-                borderRadius: BorderRadius.only(
+                borderRadius: const BorderRadius.only(
                   topLeft: Radius.circular(20.0),
                   topRight: Radius.circular(20.0),
                 ),
                 boxShadow:
-                    [BoxShadow(blurRadius: 16, color: Colors.grey)],
+                    [BoxShadow(blurRadius: 16, color: Colors.black.withOpacity(0.2))],
               ),
               child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 27),

--- a/lib/view/map_page.dart
+++ b/lib/view/map_page.dart
@@ -163,7 +163,7 @@ class MapPageState extends State<MapPage> with TickerProviderStateMixin {
                 //valueの型がInt→詳細画面
                 //int型ならそのまま、Id型ならばnullにしたい
                 int? id = (value is int) ? value : null;
-                //valueの型がHotPepper→検索から新規作成
+                //valueの型がPlaceApiRestaurantResult→新規作成画面
                 PlaceApiRestaurantResult? paResult =
                     (value is PlaceApiRestaurantResult) ? value : null;
 

--- a/lib/view/place_create_page.dart
+++ b/lib/view/place_create_page.dart
@@ -213,7 +213,6 @@ class _PlaceCreatePageState extends State<PlaceCreatePage> {
     final shop = Shop()
       ..shopName = widget.initialShopName ?? '名称未設定'
       ..shopAddress = widget.address
-      ..googleMapURL = null
       ..googlePlaceId = widget.placeId
       ..shopLatitude = widget.latlng.latitude
       ..shopLongitude = widget.latlng.longitude

--- a/lib/view/place_post_page.dart
+++ b/lib/view/place_post_page.dart
@@ -224,7 +224,6 @@ class _PlacePostPageState extends State<PlacePostPage> {
           ..id = widget.shop.id
           ..shopName = widget.shop.shopName
           ..shopAddress = widget.shop.shopAddress
-          ..googleMapURL = widget.shop.googleMapURL
           ..googlePlaceId = widget.shop.googlePlaceId
           ..shopLatitude = widget.shop.shopLatitude
           ..shopLongitude = widget.shop.shopLongitude

--- a/lib/view/place_search_page.dart
+++ b/lib/view/place_search_page.dart
@@ -236,7 +236,7 @@ class SearchResultArea extends StatelessWidget {
                         ),
                         Text(
                           _calcDistance(shop.apiResult.latlng),
-                          style: const TextStyle(fontSize: 8),
+                          style: const TextStyle(fontSize: 10),
                         ),
                       ],
                     ),
@@ -254,6 +254,9 @@ class SearchResultArea extends StatelessWidget {
                             shop.apiResult.name,
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              fontSize: 16,
+                            ),
                           ),
                           Text(
                             shop.apiResult.address,
@@ -401,6 +404,9 @@ class HistoryArea extends StatelessWidget {
                           history.name,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 16,
+                          ),
                         ),
                         Text(
                           history.address,

--- a/lib/view/place_search_page.dart
+++ b/lib/view/place_search_page.dart
@@ -38,6 +38,7 @@ class _PlaceSearchPageState extends State<PlaceSearchPage>
         isRegistered: false,
       ) 
   ];
+  TextEditingController controller = TextEditingController();
   late TabController tabController;
   bool filterRegistered = false; // 0: マップ付近の飲食店, 1: 登録済み
 
@@ -68,10 +69,12 @@ class _PlaceSearchPageState extends State<PlaceSearchPage>
           children: [
             //検索バー
             AppSearchBar(
+              controller: controller,
               autofocus: true,
               onPressClear: () {
                 setState(() {
                   searchText = "";
+                  controller.clear();
                 });
               },
               onChanged: (text) {

--- a/lib/view/place_search_page.dart
+++ b/lib/view/place_search_page.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/Cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:gohan_map/collections/shop.dart';
 import 'package:gohan_map/colors/app_colors.dart';
 import 'package:gohan_map/component/app_modal.dart';
+import 'package:gohan_map/icon/app_icon_icons.dart';
 import 'package:gohan_map/utils/apis.dart';
 import 'package:gohan_map/utils/isar_utils.dart';
 import 'package:gohan_map/utils/logger.dart';
@@ -27,9 +27,19 @@ class _PlaceSearchPageState extends State<PlaceSearchPage>
   String searchText = "";
   List<Shop> shopList = [];
   bool isLoadingPlaceApi = false;
-  List<PlaceApiRestaurantResult> placeApiRestaurants = [];
+
+  List<RestaurantResult> restaurants = [
+    RestaurantResult(
+        apiResult: PlaceApiRestaurantResult(
+            latlng: LatLng(0, 0),
+            name: "サイゼリヤサイゼリヤサイゼリヤサイゼリヤサイゼリヤ",
+            placeId: "test",
+            address: "札幌市北区北２条東1丁目サンプルサンプルサンプルサンプル"),
+        isRegistered: false,
+      ) 
+  ];
   late TabController tabController;
-  int segmentIndex = 1; // 0: マップ付近の飲食店, 1: 登録済み
+  bool filterRegistered = false; // 0: マップ付近の飲食店, 1: 登録済み
 
   @override
   void initState() {
@@ -59,6 +69,11 @@ class _PlaceSearchPageState extends State<PlaceSearchPage>
             //検索バー
             AppSearchBar(
               autofocus: true,
+              onPressClear: () {
+                setState(() {
+                  searchText = "";
+                });
+              },
               onChanged: (text) {
                 setState(() {
                   searchText = text;
@@ -71,34 +86,24 @@ class _PlaceSearchPageState extends State<PlaceSearchPage>
               },
             ),
             const SizedBox(
-              height: 24,
+              height: 20,
             ),
 
-            Center(
-              child: CupertinoSlidingSegmentedControl(
-                groupValue: segmentIndex,
-                children: const <int, Widget>{
-                  0: Text("マップ付近の店舗を登録"),
-                  1: Text("登録済み"),
-                },
-                onValueChanged: (value) {
-                  setState(() {
-                    segmentIndex = value as int;
-                  });
-                },
-              ),
-            ),
+            RegisteredFilterButton(onChanged: (value) {
+              setState(() {
+                filterRegistered = value;
+              });
+            }),
+
             const SizedBox(
-              height: 24,
+              height: 20,
             ),
 
             // マップ付近の飲食店
-            if (segmentIndex == 0)
-              NewRestaurantsTabPage(
-                  restaurantList: placeApiRestaurants,
-                  isLoading: isLoadingPlaceApi),
-            // 登録済み
-            if (segmentIndex == 1) RegisteredTabPage(shopList: shopList)
+            SearchResultArea(
+                restaurantList: restaurants,
+                isLoading: isLoadingPlaceApi,
+                filterRegistered: filterRegistered),
           ],
         ),
       ),
@@ -122,29 +127,44 @@ class _PlaceSearchPageState extends State<PlaceSearchPage>
 
     setState(() {
       isLoadingPlaceApi = true;
-      placeApiRestaurants = [];
+      restaurants = [];
     });
 
-    var restaurantsResult = await searchRestaurantsByGoogleMapApi(
+    var apiResult = await searchRestaurantsByGoogleMapApi(
       searchText,
       LatLng(widget.mapController.center.latitude,
           widget.mapController.center.longitude),
     );
 
+    List<RestaurantResult> restaurantTmp = [];
+    for (var restaurant in apiResult) {
+      var shop = await IsarUtils.getShopByGooglePlaceId(restaurant.placeId);
+      if (shop != null) {
+        restaurantTmp.add(RestaurantResult(apiResult: restaurant, isRegistered: true));
+      } else {
+        restaurantTmp.add(RestaurantResult(apiResult: restaurant, isRegistered: false));
+      }
+    }
+
     logger.d("API呼び出し");
     setState(() {
       isLoadingPlaceApi = false;
-      placeApiRestaurants = restaurantsResult;
+      restaurants = restaurantTmp;
     });
+
   }
 }
 
-class NewRestaurantsTabPage extends StatelessWidget {
-  final List<PlaceApiRestaurantResult> restaurantList;
+class SearchResultArea extends StatelessWidget {
+  final List<RestaurantResult> restaurantList;
   final bool isLoading;
+  final bool filterRegistered;
 
-  const NewRestaurantsTabPage(
-      {Key? key, required this.restaurantList, required this.isLoading})
+  const SearchResultArea(
+      {Key? key,
+      required this.restaurantList,
+      required this.isLoading,
+      this.filterRegistered = false})
       : super(key: key);
 
   @override
@@ -164,69 +184,212 @@ class NewRestaurantsTabPage extends StatelessWidget {
             child: Text("検索結果はありません"),
           ),
         for (var shop in restaurantList)
+        if (!filterRegistered || shop.isRegistered)...[
           Card(
-            //影付きの角丸四角形
-            elevation: 0, //影を消す
-            color: AppColors.whiteColor,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8), //角丸の大きさ
-            ),
-            child: ListTile(
-              title: Text(shop.name),
-              titleTextStyle: const TextStyle(
-                  fontSize: 18,
-                  color: AppColors.blackTextColor,
-                  overflow: TextOverflow.ellipsis),
-              subtitle: Text(shop.address),
-              subtitleTextStyle:
-                  const TextStyle(overflow: TextOverflow.ellipsis),
-              onTap: () {
-                Navigator.pop(context, shop);
+            margin: EdgeInsets.zero,
+            elevation: 0,
+            child: InkWell(
+              onTap: () async {
+                if (shop.isRegistered){
+                  //idを返す
+                  Shop? s = await IsarUtils.getShopByGooglePlaceId(shop.apiResult.placeId);
+                  if (s != null && context.mounted) {
+                    Navigator.pop(context, s.id);
+                  }
+                }else{
+                  //ApiResultを返す
+                  if (context.mounted) {
+                    Navigator.pop(context, shop.apiResult);
+                  }
+                }
               },
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  const Column(
+                    children: [
+                      //アイコン
+                      SizedBox(
+                        //角丸四角形
+                        width: 30,
+                        height: 34,
+                        child: Icon(
+                          AppIcons.map_marker_alt,
+                          size: 28,
+                          color: AppColors.primaryColor,
+                        ),
+                      ),
+                      Text(
+                        "1.0km",
+                        style: TextStyle(fontSize: 8),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(
+                    width: 12,
+                  ),
+                  Flexible(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const SizedBox(
+                          height: 4,
+                        ),
+                        Text(
+                          shop.apiResult.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        Text(
+                          shop.apiResult.address,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                              fontSize: 12, color: AppColors.greyDarkColor),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          child: _RegisterBudge(isRegistered: shop.isRegistered),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
+          const Divider(height: 1,thickness: 1,),
+        ],
       ],
     );
   }
 }
 
-class RegisteredTabPage extends StatelessWidget {
-  final List<Shop> shopList;
+//登録済みボタン
+class RegisteredFilterButton extends StatefulWidget {
+  const RegisteredFilterButton({
+    super.key,
+    this.initialIsUmai,
+    required this.onChanged,
+  });
 
-  const RegisteredTabPage({Key? key, required this.shopList}) : super(key: key);
+  final bool? initialIsUmai;
+  final Function(bool) onChanged;
+
+  @override
+  State<RegisteredFilterButton> createState() => _RegisteredFilterButtonState();
+}
+
+class _RegisteredFilterButtonState extends State<RegisteredFilterButton> {
+  bool isOn = false;
+
+  @override
+  void initState() {
+    super.initState();
+    isOn = widget.initialIsUmai ?? false;
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        if (shopList.isEmpty)
-          const Align(
-            alignment: Alignment.center,
-            child: Text("検索結果はありません"),
-          ),
-        for (var shop in shopList)
-          Card(
-            //影付きの角丸四角形
-            elevation: 0, //影を消す
-            color: AppColors.whiteColor,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8), //角丸の大きさ
+    return Container(
+      height: 34,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(100),
+        boxShadow: (isOn)
+            ? [
+                BoxShadow(
+                  color: AppColors.primaryColor.withOpacity(0.5),
+                  spreadRadius: 2,
+                  blurRadius: 10,
+                  offset: const Offset(0, 4),
+                )
+              ]
+            : null,
+      ),
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          elevation: (isOn) ? 3 : 0,
+          backgroundColor:
+              (isOn) ? AppColors.primaryColor : AppColors.whiteColor, //色
+          shape: RoundedRectangleBorder(
+            side: BorderSide(
+              color:
+                  (isOn) ? AppColors.primaryColor : AppColors.greyDarkColor, //色
             ),
-            child: ListTile(
-              title: Text(shop.shopName),
-              titleTextStyle: const TextStyle(
-                  fontSize: 18,
-                  color: AppColors.blackTextColor,
-                  overflow: TextOverflow.ellipsis),
-              subtitle: Text(shop.shopAddress),
-              subtitleTextStyle:
-                  const TextStyle(overflow: TextOverflow.ellipsis),
-              onTap: () {
-                Navigator.pop(context, shop.id);
-              },
-            ),
+            borderRadius: BorderRadius.circular(100),
           ),
-      ],
+          padding: EdgeInsets.zero,
+        ),
+        onPressed: () {
+          setState(() {
+            isOn = !isOn;
+            widget.onChanged(isOn);
+          });
+        },
+        child: Container(
+          //角丸四角形
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                '# 登録済み',
+                style: TextStyle(
+                  color:
+                      (isOn) ? AppColors.whiteColor : AppColors.greyDarkColor,
+                  height: 1.2,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
+}
+
+//登録可否バッジ
+class _RegisterBudge extends StatelessWidget {
+  final bool isRegistered;
+  const _RegisterBudge({super.key, required this.isRegistered});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 20,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(100),
+        color: (isRegistered) ? AppColors.redTextColor : AppColors.greyColor,
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: (isRegistered) ? 8 : 10),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isRegistered)
+              const Icon(
+                Icons.check_rounded,
+                size: 14,
+                color: AppColors.whiteColor,
+              ),
+            Text(
+              (isRegistered) ? '登録済み' : '未登録',
+              style: const TextStyle(
+                color: AppColors.whiteColor,
+                fontSize: 10,
+                height: 1.2,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+//検索結果
+class RestaurantResult {
+  late PlaceApiRestaurantResult apiResult;
+  late bool isRegistered;
+  RestaurantResult({required this.apiResult, required this.isRegistered});
 }

--- a/lib/view/place_search_page.dart
+++ b/lib/view/place_search_page.dart
@@ -144,8 +144,14 @@ class _PlaceSearchPageState extends State<PlaceSearchPage>
       }
     }
     //現在位置を取得
-    var currentLocation = await Geolocator.getCurrentPosition();
-    currentLatLng = LatLng(currentLocation.latitude, currentLocation.longitude);
+    try {
+      Position position = await Geolocator.getCurrentPosition(
+          desiredAccuracy: LocationAccuracy.high,
+          timeLimit: const Duration(seconds: 3));
+      currentLatLng = LatLng(position.latitude, position.longitude);
+    } catch (e) {
+      logger.d("現在地取得失敗");
+    }
     logger.d("API呼び出し");
     setState(() {
       isLoadingPlaceApi = false;
@@ -248,7 +254,7 @@ class SearchResultArea extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           const SizedBox(
-                            height: 10,
+                            height: 8,
                           ),
                           Text(
                             shop.apiResult.name,
@@ -256,6 +262,8 @@ class SearchResultArea extends StatelessWidget {
                             overflow: TextOverflow.ellipsis,
                             style: const TextStyle(
                               fontSize: 16,
+                              color: Colors.black,
+                              height: 1.3,
                             ),
                           ),
                           Text(
@@ -263,10 +271,13 @@ class SearchResultArea extends StatelessWidget {
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: const TextStyle(
-                                fontSize: 12, color: AppColors.greyDarkColor),
+                              fontSize: 12,
+                              color: AppColors.greyDarkColor,
+                              height: 1.3,
+                            ),
                           ),
                           Padding(
-                            padding: const EdgeInsets.fromLTRB(0, 6, 0, 12),
+                            padding: const EdgeInsets.fromLTRB(0, 4, 0, 10),
                             child:
                                 _RegisterBudge(isRegistered: shop.isRegistered),
                           ),

--- a/lib/view/place_search_page.dart
+++ b/lib/view/place_search_page.dart
@@ -248,7 +248,7 @@ class SearchResultArea extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           const SizedBox(
-                            height: 4,
+                            height: 10,
                           ),
                           Text(
                             shop.apiResult.name,
@@ -263,7 +263,7 @@ class SearchResultArea extends StatelessWidget {
                                 fontSize: 12, color: AppColors.greyDarkColor),
                           ),
                           Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 8),
+                            padding: const EdgeInsets.fromLTRB(0, 6, 0, 12),
                             child:
                                 _RegisterBudge(isRegistered: shop.isRegistered),
                           ),

--- a/lib/view/place_search_page.dart
+++ b/lib/view/place_search_page.dart
@@ -28,16 +28,7 @@ class _PlaceSearchPageState extends State<PlaceSearchPage>
   List<Shop> shopList = [];
   bool isLoadingPlaceApi = false;
 
-  List<RestaurantResult> restaurants = [
-    RestaurantResult(
-        apiResult: PlaceApiRestaurantResult(
-            latlng: LatLng(0, 0),
-            name: "サイゼリヤサイゼリヤサイゼリヤサイゼリヤサイゼリヤ",
-            placeId: "test",
-            address: "札幌市北区北２条東1丁目サンプルサンプルサンプルサンプル"),
-        isRegistered: false,
-      ) 
-  ];
+  List<RestaurantResult> restaurants = [];
   TextEditingController controller = TextEditingController();
   late TabController tabController;
   bool filterRegistered = false; // 0: マップ付近の飲食店, 1: 登録済み

--- a/lib/view/place_search_page.dart
+++ b/lib/view/place_search_page.dart
@@ -262,7 +262,6 @@ class SearchResultArea extends StatelessWidget {
                             overflow: TextOverflow.ellipsis,
                             style: const TextStyle(
                               fontSize: 16,
-                              color: Colors.black,
                               height: 1.3,
                             ),
                           ),

--- a/lib/view/place_update_page.dart
+++ b/lib/view/place_update_page.dart
@@ -231,7 +231,6 @@ class _PlaceUpdatePageState extends State<PlaceUpdatePage>
       ..id = widget.shop.id
       ..shopName = widget.shop.shopName
       ..shopAddress = widget.shop.shopAddress
-      ..googleMapURL = null
       ..googlePlaceId = widget.shop.googlePlaceId
       ..shopLatitude = widget.shop.shopLatitude
       ..shopLongitude = widget.shop.shopLongitude


### PR DESCRIPTION
## 実装内容
- 検索モーダルのデザインをFigmaに合わせる
- 登録済み店舗と未登録店舗の検索を統合する代わりに、 登録済みをフィルター機能として実装
  - 登録済み店舗をタップした場合は店舗**詳細**画面に遷移
  - 未登録店舗をタップした場合は店舗**登録**画面に遷移
  - これにより同じ店舗が複数登録される問題が修正
- 検索時のローディングの色をアプリにあわせた
- 検索履歴機能を実装
  - 検索結果をタップしたら、登録の可否に関わらずその店舗が履歴に追加される
  - 検索履歴DBを作成
  - 履歴は最大5件表示
- 距離表示機能を実装
  - 現在位置からの距離が表示される
  - 現在位置を取得できなかった場合には距離を表示しない 

resolve #103 